### PR TITLE
ci: test bor v2 beta

### DIFF
--- a/.github/tests/bor-v2-beta.yml
+++ b/.github/tests/bor-v2-beta.yml
@@ -12,6 +12,7 @@ polygon_pos_package:
     # rpcs
     - cl_type: heimdall
       el_type: bor
+      el_image: 0xpolygon/bor:2.0.0-beta2
       is_validator: false
       count: 2
     # There is an issue with erigon rpcs.

--- a/.github/tests/bor-v2-beta.yml
+++ b/.github/tests/bor-v2-beta.yml
@@ -1,0 +1,22 @@
+polygon_pos_package:
+  participants:
+    # validators
+    - cl_type: heimdall
+      cl_log_level: debug
+      el_type: bor
+      el_image: 0xpolygon/bor:2.0.0-beta2
+      el_log_level: trace
+      is_validator: true
+      count: 4
+
+    # rpcs
+    - cl_type: heimdall
+      el_type: bor
+      is_validator: false
+      count: 2
+    # There is an issue with erigon rpcs.
+    # https://github.com/0xPolygon/kurtosis-polygon-pos/issues/26
+    # - cl_type: heimdall
+    #   el_type: erigon
+    #   is_validator: false
+    #   count: 2


### PR DESCRIPTION
## Description

There have been two new bor v2 beta releases the past two weeks:

- [v2.0.0-beta](https://github.com/maticnetwork/bor/releases/tag/v2.0.0-beta)
- [v2.0.0-beta2](https://github.com/maticnetwork/bor/releases/tag/v2.0.0-beta2)

I'd like to see if it can work with the current pos package.