### PR TITLE
chore: revert to `leovct/pos-contract-deployer:node-16`

### DIFF
--- a/.github/tests/all.yml
+++ b/.github/tests/all.yml
@@ -28,7 +28,7 @@ polygon_pos_package:
       cl_type: heimdall
       is_validator: false
   setup_images:
-    contract_deployer: leovct/pos-contract-deployer:node-20
+    contract_deployer: leovct/pos-contract-deployer:node-16
     el_genesis_builder: leovct/pos-el-genesis-builder:node-16
     validator_config_generator: leovct/pos-validator-config-generator:1.2.0-e0a87ca
   network_params:

--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ polygon_pos_package:
   # Images for contract deployment and configuration.
   setup_images:
     # Image used to deploy MATIC contracts to L1.
-    # Default: "leovct/pos-contract-deployer:node-20"
-    contract_deployer: leovct/pos-contract-deployer:node-20
+    # Default: "leovct/pos-contract-deployer:node-16"
+    contract_deployer: leovct/pos-contract-deployer:node-16
     # Image used to create the L2 EL genesis file.
     # Default: "leovct/pos-el-genesis-builder:node-16"
     el_genesis_builder: leovct/pos-el-genesis-builder:node-16

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2,7 +2,7 @@ constants = import_module("./constants.star")
 math = import_module("../math/math.star")
 sanity_check = import_module("./sanity_check.star")
 
-DEFAULT_POS_CONTRACT_DEPLOYER_IMAGE = "leovct/pos-contract-deployer:node-20"
+DEFAULT_POS_CONTRACT_DEPLOYER_IMAGE = "leovct/pos-contract-deployer:node-16"
 DEFAULT_POS_EL_GENESIS_BUILDER_IMAGE = "leovct/pos-el-genesis-builder:node-16"
 DEFAULT_POS_VALIDATOR_CONFIG_GENERATOR_IMAGE = "leovct/pos-validator-config-generator:1.2.0-e0a87ca"  # Based on 0xpolygon/heimdall:1.2.0 and leovct/heimdall-v2:e0a87ca.
 


### PR DESCRIPTION
While testing state syncs, there were some issues with `node-20`. It's not ready yet. For now, we'll use `node-16`.