### PR TITLE
fix: sanity check

### DIFF
--- a/main.star
+++ b/main.star
@@ -28,20 +28,20 @@ constants = import_module("./src/package_io/constants.star")
 def run(plan, args):
     # Parse L1, L2 and dev input args.
     args = input_parser.input_parser(plan, args)
-    ethereum_args = args.get("ethereum_package", {})
-    polygon_pos_args = args.get("polygon_pos_package", {})
-    dev_args = args.get("dev", {})
+    ethereum_args = args.get("ethereum_package")
+    polygon_pos_args = args.get("polygon_pos_package")
+    dev_args = args.get("dev")
 
-    participants = polygon_pos_args.get("participants", {})
+    participants = polygon_pos_args.get("participants")
     validator_accounts = get_validator_accounts(participants)
-    l2_network_params = polygon_pos_args.get("network_params", {})
+    l2_network_params = polygon_pos_args.get("network_params")
 
     # Determine the devnet CL type to be able to select the appropriate validator address format later.
     devnet_cl_type = participants[0].get("cl_type")
 
     # Deploy a local L1 if needed.
     # Otherwise, use the provided rpc url.
-    if dev_args.get("should_deploy_l1", True):
+    if dev_args.get("should_deploy_l1"):
         plan.print(
             "Deploying a local L1 with the following input args: {}".format(
                 ethereum_args
@@ -50,7 +50,7 @@ def run(plan, args):
         l1 = deploy_local_l1(
             plan,
             ethereum_args,
-            l2_network_params.get("preregistered_validator_keys_mnemonic", ""),
+            l2_network_params.get("preregistered_validator_keys_mnemonic"),
         )
         prefunded_accounts_count = len(l1.pre_funded_accounts)
         if prefunded_accounts_count < 13:
@@ -75,14 +75,14 @@ def run(plan, args):
     else:
         plan.print("Using an external l1")
         l1_context = struct(
-            private_key=dev_args.get("l1_private_key", ""),
-            rpc_url=dev_args.get("l1_rpc_url", ""),
+            private_key=dev_args.get("l1_private_key"),
+            rpc_url=dev_args.get("l1_rpc_url"),
         )
-        l1_rpcs = {"external-l1": dev_args.get("l1_rpc_url", "")}
+        l1_rpcs = {"external-l1": dev_args.get("l1_rpc_url")}
 
     # Deploy MATIC contracts and generate the EL and CL genesis files if needed.
     # Otherwise, use the provided EL and CL genesis files.
-    if dev_args.get("should_deploy_matic_contracts", True):
+    if dev_args.get("should_deploy_matic_contracts"):
         plan.print("Number of validators: {}".format(len(validator_accounts)))
         plan.print(validator_accounts)
 
@@ -133,7 +133,7 @@ def run(plan, args):
             name="l2-el-genesis",
             config={
                 "genesis.json": struct(
-                    template=read_file(src=dev_args.get("l2_el_genesis_filepath", "")),
+                    template=read_file(src=dev_args.get("l2_el_genesis_filepath")),
                     data={},
                 )
             },
@@ -142,14 +142,14 @@ def run(plan, args):
             name="l2-cl-genesis",
             config={
                 "genesis.json": struct(
-                    template=read_file(src=dev_args.get("l2_cl_genesis_filepath", "")),
+                    template=read_file(src=dev_args.get("l2_cl_genesis_filepath")),
                     data={},
                 )
             },
         )
 
     # Deploy network participants.
-    participants_count = math.sum([p.get("count", 1) for p in participants])
+    participants_count = math.sum([p.get("count") for p in participants])
     plan.print(
         "Launching a Polygon PoS devnet with {} participants, including {} validators, and the following network params: {}".format(
             participants_count, len(validator_accounts), participants
@@ -166,7 +166,7 @@ def run(plan, args):
     )
 
     # Deploy additional services.
-    additional_services = polygon_pos_args.get("additional_services", [])
+    additional_services = polygon_pos_args.get("additional_services")
     for svc in additional_services:
         if svc == constants.ADDITIONAL_SERVICES.blockscout:
             blockscout.launch(plan)
@@ -190,8 +190,8 @@ def get_validator_accounts(participants):
     validator_accounts = []
     participant_index = 0
     for participant in participants:
-        for _ in range(participant.get("count", 1)):
-            if participant.get("is_validator", False):
+        for _ in range(participant.get("count")):
+            if participant.get("is_validator"):
                 if participant_index >= len(prefunded_accounts):
                     fail(
                         "Having more than {} validators is not supported for now.".format(
@@ -225,8 +225,8 @@ def deploy_local_l1(plan, ethereum_args, preregistered_validator_keys_mnemonic):
     prefunded_accounts = account_util.to_ethereum_pkg_prefunded_accounts(
         pre_funded_accounts.PRE_FUNDED_ACCOUNTS,
     )
-    l1_network_params = ethereum_args.get("network_params", {})
-    user_prefunded_accounts_str = l1_network_params.get("prefunded_accounts", "")
+    l1_network_params = ethereum_args.get("network_params")
+    user_prefunded_accounts_str = l1_network_params.get("prefunded_accounts")
     if user_prefunded_accounts_str != "":
         user_prefunded_accounts = json.decode(user_prefunded_accounts_str)
         prefunded_accounts = prefunded_accounts | user_prefunded_accounts

--- a/main.star
+++ b/main.star
@@ -213,11 +213,9 @@ def deploy_local_l1(plan, ethereum_args, preregistered_validator_keys_mnemonic):
     # Sanity check the mnemonic used.
     # TODO: Remove this limitation.
     l2_network_params = input_parser.DEFAULT_POLYGON_POS_PACKAGE_ARGS.get(
-        "network_params", {}
+        "network_params"
     )
-    default_l2_mnemonic = l2_network_params.get(
-        "preregistered_validator_keys_mnemonic", ""
-    )
+    default_l2_mnemonic = l2_network_params.get("preregistered_validator_keys_mnemonic")
     if preregistered_validator_keys_mnemonic != default_l2_mnemonic:
         fail("Using a different mnemonic is not supported for now.")
 
@@ -226,7 +224,7 @@ def deploy_local_l1(plan, ethereum_args, preregistered_validator_keys_mnemonic):
         pre_funded_accounts.PRE_FUNDED_ACCOUNTS,
     )
     l1_network_params = ethereum_args.get("network_params")
-    user_prefunded_accounts_str = l1_network_params.get("prefunded_accounts")
+    user_prefunded_accounts_str = l1_network_params.get("prefunded_accounts", "")
     if user_prefunded_accounts_str != "":
         user_prefunded_accounts = json.decode(user_prefunded_accounts_str)
         prefunded_accounts = prefunded_accounts | user_prefunded_accounts

--- a/main.star
+++ b/main.star
@@ -224,7 +224,7 @@ def deploy_local_l1(plan, ethereum_args, preregistered_validator_keys_mnemonic):
         pre_funded_accounts.PRE_FUNDED_ACCOUNTS,
     )
     l1_network_params = ethereum_args.get("network_params")
-    user_prefunded_accounts_str = l1_network_params.get("prefunded_accounts", "")
+    user_prefunded_accounts_str = l1_network_params.get("prefunded_accounts")
     if user_prefunded_accounts_str != "":
         user_prefunded_accounts = json.decode(user_prefunded_accounts_str)
         prefunded_accounts = prefunded_accounts | user_prefunded_accounts

--- a/src/additional_services/prometheus_grafana.star
+++ b/src/additional_services/prometheus_grafana.star
@@ -43,7 +43,7 @@ def get_l2_config(plan, participants):
     validator_index = 0
 
     for participant in participants:
-        for _ in range(participant.get("count", 1)):
+        for _ in range(participant.get("count")):
             el_node_name = el_cl_launcher._generate_el_node_name(
                 participant, participant_index + 1
             )
@@ -54,7 +54,7 @@ def get_l2_config(plan, participants):
             )
 
             participant_index += 1
-            if not participant.get("is_validator", False):
+            if not participant.get("is_validator"):
                 continue
 
             cl_node_name = el_cl_launcher._generate_cl_node_name(

--- a/src/cl/heimdall/heimdall_launcher.star
+++ b/src/cl/heimdall/heimdall_launcher.star
@@ -53,7 +53,7 @@ def launch(
                 data={
                     # Node params.
                     "moniker": cl_node_name,
-                    "log_level": participant.get("cl_log_level", ""),
+                    "log_level": participant.get("cl_log_level"),
                     "persistent_peers": cl_node_ids,
                     # Port numbers.
                     "proxy_app_port_number": HEIMDALL_PROXY_LISTEN_PORT_NUMBER,

--- a/src/cl/heimdall_v2/heimdall_v2_launcher.star
+++ b/src/cl/heimdall_v2/heimdall_v2_launcher.star
@@ -26,12 +26,10 @@ def launch(
                 ),
                 data={
                     # Network params.
-                    "span_poll_interval": network_params.get(
-                        "cl_span_poll_interval", ""
-                    ),
-                    "checkpoint_poll_interval": network_params[
+                    "span_poll_interval": network_params.get("cl_span_poll_interval"),
+                    "checkpoint_poll_interval": network_params.get(
                         "cl_checkpoint_poll_interval"
-                    ],
+                    ),
                     # URLs.
                     "amqp_url": amqp_url,
                     "el_rpc_url": el_rpc_url,

--- a/src/cl/heimdall_v2/heimdall_v2_launcher.star
+++ b/src/cl/heimdall_v2/heimdall_v2_launcher.star
@@ -67,7 +67,7 @@ def launch(
                     "{}/client.toml".format(HEIMDALL_TEMPLATES_FOLDER_PATH),
                 ),
                 data={
-                    "cl_chain_id": network_params.get("cl_chain_id", ""),
+                    "cl_chain_id": network_params.get("cl_chain_id"),
                     "cometbft_rpc_port_number": HEIMDALL_RPC_PORT_NUMBER,
                 },
             ),
@@ -78,7 +78,7 @@ def launch(
                 data={
                     # Node params.
                     "moniker": cl_node_name,
-                    "log_level": participant.get("cl_log_level", ""),
+                    "log_level": participant.get("cl_log_level"),
                     "persistent_peers": cl_node_ids,
                     # Port numbers.
                     "proxy_app_port_number": HEIMDALL_PROXY_LISTEN_PORT_NUMBER,

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -28,9 +28,7 @@ def deploy_contracts(plan, l1_context, polygon_pos_args, validator_accounts):
             "CL_CHAIN_ID": network_params.get("cl_chain_id"),
             "VALIDATOR_ACCOUNTS": validator_accounts_formatted,
             "VALIDATOR_BALANCE": str(constants.VALIDATORS_BALANCE_ETH),
-            "VALIDATOR_STAKE_AMOUNT": str(
-                network_params.get("validator_stake_amount")
-            ),
+            "VALIDATOR_STAKE_AMOUNT": str(network_params.get("validator_stake_amount")),
             "VALIDATOR_TOP_UP_FEE_AMOUNT": str(
                 network_params.get("validator_top_up_fee_amount")
             ),

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -4,8 +4,8 @@ CONTRACTS_CONFIG_FILE_PATH = "../../static_files/contracts"
 
 
 def deploy_contracts(plan, l1_context, polygon_pos_args, validator_accounts):
-    network_params = polygon_pos_args.get("network_params", {})
-    setup_images = polygon_pos_args.get("setup_images", {})
+    network_params = polygon_pos_args.get("network_params")
+    setup_images = polygon_pos_args.get("setup_images")
     contract_deployer_image = setup_images.get("contract_deployer")
     contract_setup_script = _determine_contract_setup_script(contract_deployer_image)
 
@@ -23,16 +23,16 @@ def deploy_contracts(plan, l1_context, polygon_pos_args, validator_accounts):
         env_vars={
             "PRIVATE_KEY": l1_context.private_key,
             "L1_RPC_URL": l1_context.rpc_url,
-            "EL_CHAIN_ID": network_params.get("el_chain_id", ""),
+            "EL_CHAIN_ID": network_params.get("el_chain_id"),
             "DEFAULT_EL_CHAIN_ID": constants.DEFAULT_EL_CHAIN_ID,
-            "CL_CHAIN_ID": network_params.get("cl_chain_id", ""),
+            "CL_CHAIN_ID": network_params.get("cl_chain_id"),
             "VALIDATOR_ACCOUNTS": validator_accounts_formatted,
             "VALIDATOR_BALANCE": str(constants.VALIDATORS_BALANCE_ETH),
             "VALIDATOR_STAKE_AMOUNT": str(
-                network_params.get("validator_stake_amount", 0)
+                network_params.get("validator_stake_amount")
             ),
             "VALIDATOR_TOP_UP_FEE_AMOUNT": str(
-                network_params.get("validator_top_up_fee_amount", 0)
+                network_params.get("validator_top_up_fee_amount")
             ),
         },
         files={

--- a/src/el/bor/bor_launcher.star
+++ b/src/el/bor/bor_launcher.star
@@ -32,7 +32,7 @@ def launch(
     el_static_nodes,
     el_chain_id,
 ):
-    is_validator = participant.get("is_validator", False)
+    is_validator = participant.get("is_validator")
     bor_node_config_artifact = plan.render_templates(
         name="{}-node-config".format(el_node_name),
         config={
@@ -47,7 +47,7 @@ def launch(
                     "address": el_account.eth_tendermint.address,
                     "cl_node_url": cl_node_url,
                     "log_level_to_int": log_level_to_int(
-                        participant.get("el_log_level", "")
+                        participant.get("el_log_level")
                     ),
                     # network params
                     "static_nodes": str(el_static_nodes),

--- a/src/el/erigon/erigon_launcher.star
+++ b/src/el/erigon/erigon_launcher.star
@@ -30,7 +30,7 @@ def launch(
     el_static_nodes,
     el_chain_id,
 ):
-    is_validator = participant.get("is_validator", False)
+    is_validator = participant.get("is_validator")
     erigon_node_config_artifact = plan.render_templates(
         name="{}-node-config".format(el_node_name),
         config={
@@ -43,7 +43,7 @@ def launch(
                     "data_folder_path": ERIGON_APP_DATA_FOLDER_PATH,
                     "address": el_account.eth_tendermint.address,
                     "cl_node_url": cl_node_url,
-                    "log_level": participant.get("el_log_level", ""),
+                    "log_level": participant.get("el_log_level"),
                     # network params.
                     "el_chain_id": el_chain_id,
                     "static_nodes": ",".join(el_static_nodes),

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -24,8 +24,8 @@ def launch(
     l1_rpc_url,
     devnet_cl_type,
 ):
-    network_params = polygon_pos_args.get("network_params", {})
-    setup_images = polygon_pos_args.get("setup_images", {})
+    network_params = polygon_pos_args.get("network_params")
+    setup_images = polygon_pos_args.get("setup_images")
 
     el_launchers = {
         "bor": {
@@ -67,9 +67,9 @@ def launch(
     participant_index = 0
     validator_index = 0
     for _, participant in enumerate(participants):
-        for _ in range(participant.get("count", 1)):
+        for _ in range(participant.get("count")):
             # Get the CL launcher.
-            cl_type = participant.get("cl_type", "")
+            cl_type = participant.get("cl_type")
             if cl_type not in cl_launchers:
                 fail(
                     "Unsupported CL launcher '{0}', need one of '{1}'".format(
@@ -80,7 +80,7 @@ def launch(
             cl_launch_method = cl_launchers[cl_type]["launch_method"]
 
             # Get the EL launcher.
-            el_type = participant.get("el_type", "")
+            el_type = participant.get("el_type")
             if el_type not in el_launchers:
                 fail(
                     "Unsupported EL launcher '{0}', need one of '{1}'".format(
@@ -97,7 +97,7 @@ def launch(
             )
 
             # If the participant is a validator, launch the CL node and it's dedicated AMQP server.
-            if participant.get("is_validator", False):
+            if participant.get("is_validator"):
                 rabbitmq_name = _generate_amqp_name(participant_index + 1)
                 rabbitmq_service = plan.add_service(
                     name=rabbitmq_name,
@@ -138,7 +138,7 @@ def launch(
             # Launch the EL node.
             el_validator_config_artifact = (
                 validator_config_artifacts.el_configs[validator_index]
-                if participant.get("is_validator", False)
+                if participant.get("is_validator")
                 else None
             )
             el_context = el_launch_method(
@@ -150,12 +150,12 @@ def launch(
                 cl_node_url,
                 pre_funded_accounts.PRE_FUNDED_ACCOUNTS[participant_index],
                 network_data.el_static_nodes,
-                network_params.get("el_chain_id", ""),
+                network_params.get("el_chain_id"),
             )
 
             # Increment the indexes.
             participant_index += 1
-            if participant.get("is_validator", False):
+            if participant.get("is_validator"):
                 validator_index += 1
 
 
@@ -175,8 +175,8 @@ def _prepare_network_data(participants):
     participant_index = 0
     validator_index = 0
     for _, participant in enumerate(participants):
-        for _ in range(participant.get("count", 1)):
-            if participant.get("is_validator", False):
+        for _ in range(participant.get("count")):
+            if participant.get("is_validator"):
                 cl_node_name = _generate_cl_node_name(
                     participant, participant_index + 1
                 )
@@ -262,8 +262,8 @@ def _generate_validator_config(
     polygon_pos_args,
     devnet_cl_type,
 ):
-    setup_images = polygon_pos_args.get("setup_images", {})
-    network_params = polygon_pos_args.get("network_params", {})
+    setup_images = polygon_pos_args.get("setup_images")
+    network_params = polygon_pos_args.get("network_params")
 
     # Generate CL validators configuration such as the public/private keys and node identifiers.
     validator_config_generator_artifact = plan.upload_files(
@@ -277,7 +277,7 @@ def _generate_validator_config(
         image=setup_images.get("validator_config_generator"),
         env_vars={
             "DEVNET_CL_TYPE": devnet_cl_type,
-            "CL_CHAIN_ID": network_params.get("cl_chain_id", ""),
+            "CL_CHAIN_ID": network_params.get("cl_chain_id"),
             "CL_CLIENT_CONFIG_PATH": constants.CL_CLIENT_CONFIG_PATH,
             "EL_CLIENT_CONFIG_PATH": constants.EL_CLIENT_CONFIG_PATH,
             "CL_VALIDATORS_CONFIGS": cl_validator_configs_str,
@@ -322,7 +322,7 @@ def _read_cl_persistent_peers(plan, cl_persistent_peers_artifact):
 
 def _generate_cl_node_name(participant, id):
     return "l2-cl-{}-{}-{}-validator".format(
-        id, participant.get("cl_type", ""), participant.get("el_type", "")
+        id, participant.get("cl_type"), participant.get("el_type")
     )
 
 
@@ -333,7 +333,7 @@ def _generate_amqp_name(id):
 def _generate_el_node_name(participant, id):
     return "l2-el-{}-{}-{}-{}".format(
         id,
-        participant.get("el_type", ""),
-        participant.get("cl_type", ""),
-        "validator" if participant.get("is_validator", False) else "rpc",
+        participant.get("el_type"),
+        participant.get("cl_type"),
+        "validator" if participant.get("is_validator") else "rpc",
     )

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -135,8 +135,6 @@ def _parse_polygon_pos_args(plan, polygon_pos_args):
     if polygon_pos_args:
         polygon_pos_args = dict(polygon_pos_args)
 
-    sanity_check.sanity_check_polygon_args(plan, polygon_pos_args)
-
     # Parse the polygon pos input args and set defaults if needed.
     result = {}
 
@@ -152,7 +150,8 @@ def _parse_polygon_pos_args(plan, polygon_pos_args):
     additional_services = polygon_pos_args.get("additional_services", [])
     result["additional_services"] = _parse_additional_services(additional_services)
 
-    # Sort the dict and return the result.
+    # Sanity check and return the result.
+    sanity_check.sanity_check_polygon_args(plan, result)
     return _sort_dict_by_values(result)
 
 
@@ -160,8 +159,6 @@ def _parse_dev_args(plan, dev_args):
     # Create a mutable copy of dev_args.
     if dev_args:
         dev_args = dict(dev_args)
-
-    sanity_check.sanity_check_dev_args(plan, dev_args)
 
     # Set default params if not provided.
     if "should_deploy_l1" not in dev_args:
@@ -172,7 +169,8 @@ def _parse_dev_args(plan, dev_args):
             "should_deploy_matic_contracts", True
         )
 
-    # Sort the dict and return the result.
+    # Sanity check and return the result.
+    sanity_check.sanity_check_dev_args(plan, dev_args)
     return _sort_dict_by_values(dev_args)
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -36,6 +36,7 @@ DEFAULT_ETHEREUM_PACKAGE_ARGS = {
         "preset": "minimal",
         "seconds_per_slot": 1,
         "network_id": constants.DEFAULT_L1_CHAIN_ID,
+        "prefunded_accounts": "",
     },
 }
 
@@ -175,14 +176,12 @@ def _parse_dev_args(plan, dev_args):
 
 
 def _parse_participants(participants):
+    devnet_cl_type = ""
     participants_with_defaults = []
 
     # Set default participant if not provided.
     if len(participants) == 0:
         participants = DEFAULT_POLYGON_POS_PACKAGE_ARGS.get("participants", [])
-
-    # Determine the devnet CL type.
-    devnet_cl_type = participants[0].get("cl_type")
 
     for p in participants:
         # Create a mutable copy of participant.
@@ -213,6 +212,10 @@ def _parse_participants(participants):
         # Fill in any missing fields with default values.
         for k, v in DEFAULT_POLYGON_POS_PARTICIPANT.items():
             p.setdefault(k, v)
+
+        # Set devnet CL type using the first participant CL type.
+        if devnet_cl_type == "":
+            devnet_cl_type = p.get("cl_type")
 
         # Make sure that CL types have not been mixed.
         if p.get("cl_type") != devnet_cl_type:

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -73,11 +73,11 @@ def sanity_check_polygon_args(plan, input_args):
     _validate_list(input_args, "additional_services")
 
     # Validate values.
-    network_params = input_args.get("network_params", {})
-    cl_chain_id = network_params.get("cl_chain_id", "")
-    el_chain_id = network_params.get("el_chain_id", "")
+    network_params = input_args.get("network_params")
+    cl_chain_id = network_params.get("cl_chain_id")
+    el_chain_id = network_params.get("el_chain_id")
     validate_chain_ids(cl_chain_id, el_chain_id)
-    for p in input_args.get("participants", []):
+    for p in input_args.get("participants"):
         _validate_participant(p)
 
     plan.print("Sanity check passed")
@@ -92,32 +92,32 @@ def sanity_check_dev_args(plan, input_args):
             )
 
     # Validate values.
-    should_deploy_l1 = input_args.get("should_deploy_l1", True)
+    should_deploy_l1 = input_args.get("should_deploy_l1")
     should_deploy_matic_contracts = input_args.get(
         "should_deploy_matic_contracts", True
     )
 
     if not should_deploy_l1:
-        l1_private_key = input_args.get("l1_private_key", "")
+        l1_private_key = input_args.get("l1_private_key")
         if l1_private_key == "" and should_deploy_matic_contracts:
             fail(
                 "`dev.l1_private_key` must be specified when `dev.should_deploy_l1` is set to false and `dev.should_deploy_matic_contracts` is set to true!"
             )
 
-        l1_rpc_url = input_args.get("l1_rpc_url", "")
+        l1_rpc_url = input_args.get("l1_rpc_url")
         if l1_rpc_url == "":
             fail(
                 "`dev.l1_rpc_url` must be specified when `dev.should_deploy_l1` is set to false!"
             )
 
     if not should_deploy_matic_contracts:
-        l2_el_genesis_filepath = input_args.get("l2_el_genesis_filepath", "")
+        l2_el_genesis_filepath = input_args.get("l2_el_genesis_filepath")
         if l2_el_genesis_filepath == "":
             fail(
                 "`dev.l2_el_genesis_filepath` must be specified when `dev.should_deploy_matic_contracts` is set to false!"
             )
 
-        l2_cl_genesis_filepath = input_args.get("l2_cl_genesis_filepath", "")
+        l2_cl_genesis_filepath = input_args.get("l2_cl_genesis_filepath")
         if l2_cl_genesis_filepath == "":
             fail(
                 "`dev.l2_cl_genesis_filepath` must be specified when `dev.should_deploy_matic_contracts` is set to false!"
@@ -225,12 +225,12 @@ def _validate_participant(p):
         constants.LOG_LEVEL.info,
         constants.LOG_LEVEL.debug,
     ]
-    if p.get("cl_type", "") == constants.CL_TYPE.heimdall and p.get(
+    if p.get("cl_type") == constants.CL_TYPE.heimdall and p.get(
         "cl_log_level", ""
     ) not in heimdall_v1_log_levels + [""]:
         fail(
             'Heimdall (v1) does not support "{}" log level. Valid log levels are: "{}"'.format(
-                p.get("cl_log_level", ""), heimdall_v1_log_levels
+                p.get("cl_log_level"), heimdall_v1_log_levels
             )
         )
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -92,10 +92,8 @@ def sanity_check_dev_args(plan, input_args):
             )
 
     # Validate values.
-    should_deploy_l1 = input_args.get("should_deploy_l1", True)
-    should_deploy_matic_contracts = input_args.get(
-        "should_deploy_matic_contracts", True
-    )
+    should_deploy_l1 = input_args.get("should_deploy_l1")
+    should_deploy_matic_contracts = input_args.get("should_deploy_matic_contracts")
 
     if not should_deploy_l1:
         l1_private_key = input_args.get("l1_private_key")

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -92,7 +92,7 @@ def sanity_check_dev_args(plan, input_args):
             )
 
     # Validate values.
-    should_deploy_l1 = input_args.get("should_deploy_l1")
+    should_deploy_l1 = input_args.get("should_deploy_l1", True)
     should_deploy_matic_contracts = input_args.get(
         "should_deploy_matic_contracts", True
     )

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -224,7 +224,7 @@ def _validate_participant(p):
         constants.LOG_LEVEL.debug,
     ]
     if p.get("cl_type") == constants.CL_TYPE.heimdall and p.get(
-        "cl_log_level", ""
+        "cl_log_level"
     ) not in heimdall_v1_log_levels + [""]:
         fail(
             'Heimdall (v1) does not support "{}" log level. Valid log levels are: "{}"'.format(

--- a/src/prelaunch_data_generator/cl_genesis/cl_genesis_generator.star
+++ b/src/prelaunch_data_generator/cl_genesis/cl_genesis_generator.star
@@ -17,7 +17,7 @@ def generate_cl_genesis_data(
     validator_accounts,
     contract_addresses_artifact,
 ):
-    network_params = polygon_pos_args.get("network_params", {})
+    network_params = polygon_pos_args.get("network_params")
     validators_number = len(validator_accounts)
 
     cl_type_specific_data = {}
@@ -50,7 +50,7 @@ def generate_cl_genesis_data(
             "total_voting_power": validator_data.total_voting_power,
         }
 
-    el_span_duration = network_params.get("el_span_duration", "")
+    el_span_duration = network_params.get("el_span_duration")
     contract_addresses = contract_util.read_contract_addresses(
         plan, contract_addresses_artifact
     )
@@ -67,22 +67,22 @@ def generate_cl_genesis_data(
                 ),
                 data={
                     # chain params
-                    "cl_chain_id": network_params.get("cl_chain_id", ""),
-                    "el_chain_id": network_params.get("el_chain_id", ""),
-                    "el_sprint_duration": network_params.get("el_sprint_duration", ""),
+                    "cl_chain_id": network_params.get("cl_chain_id"),
+                    "el_chain_id": network_params.get("el_chain_id"),
+                    "el_sprint_duration": network_params.get("el_sprint_duration"),
                     "el_span_duration": el_span_duration,
                     "el_first_span_end_block": el_span_duration - 1,
                     # contract addresses
-                    "matic_token_address": contract_addresses.get("matic_token", ""),
+                    "matic_token_address": contract_addresses.get("matic_token"),
                     "staking_manager_address": contract_addresses.get(
                         "staking_manager", ""
                     ),
                     "slash_manager_address": contract_addresses.get(
                         "slashing_manager", ""
                     ),
-                    "root_chain_address": contract_addresses.get("root_chain", ""),
-                    "staking_info_address": contract_addresses.get("staking_info", ""),
-                    "state_sender_address": contract_addresses.get("state_sender", ""),
+                    "root_chain_address": contract_addresses.get("root_chain"),
+                    "staking_info_address": contract_addresses.get("staking_info"),
+                    "state_sender_address": contract_addresses.get("state_sender"),
                 }
                 | cl_type_specific_data,
             ),

--- a/src/prelaunch_data_generator/cl_genesis/cl_genesis_generator.star
+++ b/src/prelaunch_data_generator/cl_genesis/cl_genesis_generator.star
@@ -75,11 +75,9 @@ def generate_cl_genesis_data(
                     # contract addresses
                     "matic_token_address": contract_addresses.get("matic_token"),
                     "staking_manager_address": contract_addresses.get(
-                        "staking_manager", ""
+                        "staking_manager"
                     ),
-                    "slash_manager_address": contract_addresses.get(
-                        "slashing_manager", ""
-                    ),
+                    "slash_manager_address": contract_addresses.get("slashing_manager"),
                     "root_chain_address": contract_addresses.get("root_chain"),
                     "staking_info_address": contract_addresses.get("staking_info"),
                     "state_sender_address": contract_addresses.get("state_sender"),

--- a/src/prelaunch_data_generator/el_genesis/el_genesis_generator.star
+++ b/src/prelaunch_data_generator/el_genesis/el_genesis_generator.star
@@ -21,7 +21,7 @@ def generate_el_genesis_data(plan, polygon_pos_args, validator_config_artifact):
                 data={
                     "el_chain_id": network_params.get("el_chain_id"),
                     "el_block_interval_seconds": network_params.get(
-                        "el_block_interval_seconds", ""
+                        "el_block_interval_seconds"
                     ),
                     "el_sprint_duration": network_params.get("el_sprint_duration"),
                     "el_gas_limit_hex": hex.int_to_hex(

--- a/src/prelaunch_data_generator/el_genesis/el_genesis_generator.star
+++ b/src/prelaunch_data_generator/el_genesis/el_genesis_generator.star
@@ -9,8 +9,8 @@ EL_GENESIS_TEMPLATE_FILE_PATH = "../../../static_files/genesis/el/genesis.json"
 
 
 def generate_el_genesis_data(plan, polygon_pos_args, validator_config_artifact):
-    network_params = polygon_pos_args.get("network_params", {})
-    setup_images = polygon_pos_args.get("setup_images", {})
+    network_params = polygon_pos_args.get("network_params")
+    setup_images = polygon_pos_args.get("setup_images")
 
     # Generate a temporary EL genesis with an empty `alloc` field.
     el_genesis_temporary_artifact = plan.render_templates(
@@ -19,13 +19,13 @@ def generate_el_genesis_data(plan, polygon_pos_args, validator_config_artifact):
             "genesis.json": struct(
                 template=read_file(EL_GENESIS_TEMPLATE_FILE_PATH),
                 data={
-                    "el_chain_id": network_params.get("el_chain_id", ""),
+                    "el_chain_id": network_params.get("el_chain_id"),
                     "el_block_interval_seconds": network_params.get(
                         "el_block_interval_seconds", ""
                     ),
-                    "el_sprint_duration": network_params.get("el_sprint_duration", ""),
+                    "el_sprint_duration": network_params.get("el_sprint_duration"),
                     "el_gas_limit_hex": hex.int_to_hex(
-                        network_params.get("el_gas_limit", 0)
+                        network_params.get("el_gas_limit")
                     ),
                 },
             )
@@ -42,9 +42,9 @@ def generate_el_genesis_data(plan, polygon_pos_args, validator_config_artifact):
         description="Generating L2 EL genesis",
         image=setup_images.get("el_genesis_builder"),
         env_vars={
-            "EL_CHAIN_ID": network_params.get("el_chain_id", ""),
+            "EL_CHAIN_ID": network_params.get("el_chain_id"),
             "DEFAULT_EL_CHAIN_ID": constants.DEFAULT_EL_CHAIN_ID,
-            "CL_CHAIN_ID": network_params.get("cl_chain_id", ""),
+            "CL_CHAIN_ID": network_params.get("cl_chain_id"),
             "DEFAULT_CL_CHAIN_ID": constants.DEFAULT_CL_CHAIN_ID,
         },
         files={


### PR DESCRIPTION
## Description

- The new process is to parse arguments first, then add default values, and finally do sanity checks. Before, the order was parse arguments, sanity checks, and then add default values.
- Remove all the defaults values when using `.get()`. The package should fail if a value is missing instead of running with wrong values.