### PR TITLE
Update heimdall v2 configs

### DIFF
--- a/static_files/heimdall_v2/app.toml
+++ b/static_files/heimdall_v2/app.toml
@@ -276,4 +276,4 @@ eth_rpc_timeout = "5m0s"
 bor_rpc_timeout = "5m0s"
 no_ack_wait_time = "30m0s"
 
-chain = "mainnet"
+chain = ""

--- a/static_files/heimdall_v2/config.toml
+++ b/static_files/heimdall_v2/config.toml
@@ -392,21 +392,21 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "3s"
+timeout_propose = "1000ms"
 # How much timeout_propose increases with each round
-timeout_propose_delta = "500ms"
+timeout_propose_delta = "200ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)
-timeout_prevote = "1s"
+timeout_prevote = "500ms"
 # How much the timeout_prevote increases with each round
-timeout_prevote_delta = "500ms"
+timeout_prevote_delta = "200ms"
 # How long we wait after receiving +2/3 precommits for “anything” (ie. not a single block or nil)
-timeout_precommit = "1s"
+timeout_precommit = "500ms"
 # How much the timeout_precommit increases with each round
-timeout_precommit_delta = "500ms"
+timeout_precommit_delta = "200ms"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-timeout_commit = "5s"
+timeout_commit = "500ms"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart
@@ -422,8 +422,8 @@ create_empty_blocks = true
 create_empty_blocks_interval = "0s"
 
 # Reactor sleep duration parameters
-peer_gossip_sleep_duration = "100ms"
-peer_query_maj23_sleep_duration = "2s"
+peer_gossip_sleep_duration = "25ms"
+peer_query_maj23_sleep_duration = "500ms"
 
 #######################################################
 ###         Storage Configuration Options           ###


### PR DESCRIPTION
Change the default network from mainnet to devnet. Otherwise, some features, such as milestone, won't be enabled at block 0. Also reduce heimdall block time from 5-6s to 1-1.5s. 