### PR TITLE
fix: wait for l2 startup should target the first CL node

### DIFF
--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -170,7 +170,9 @@ def launch(
 
     # Wait for the devnet to reach a certain state.
     # The first producer should have committed a span.
-    wait.wait_for_l2_startup(plan, first_cl_api_url, network_data.first_validator_cl_type)
+    wait.wait_for_l2_startup(
+        plan, first_cl_api_url, network_data.first_validator_cl_type
+    )
 
     # Return the L2 context.
     return context

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -53,7 +53,7 @@ def launch(
 
     # Prepare network data and generate validator configs.
     network_data = _prepare_network_data(participants)
-    cl_api_url = network_data.first_validator_cl_api_url
+    first_cl_api_url = network_data.first_validator_cl_api_url
     validator_config_artifacts = _generate_validator_config(
         plan,
         network_data.cl_validator_configs_str,
@@ -102,6 +102,7 @@ def launch(
 
             # If the participant is a validator, launch the CL node and it's dedicated AMQP server.
             cl_context = {}
+            cl_api_url = first_cl_api_url
             if participant.get("is_validator"):
                 rabbitmq_name = _generate_amqp_name(participant_index + 1)
                 rabbitmq_service = plan.add_service(
@@ -169,7 +170,7 @@ def launch(
 
     # Wait for the devnet to reach a certain state.
     # The first producer should have committed a span.
-    wait.wait_for_l2_startup(plan, cl_api_url, network_data.first_validator_cl_type)
+    wait.wait_for_l2_startup(plan, first_cl_api_url, network_data.first_validator_cl_type)
 
     # Return the L2 context.
     return context


### PR DESCRIPTION
## Description

Wait for L2 startup targets the last CL node instead of the first one...

<img width="1226" alt="Screenshot 2025-02-25 at 18 46 41" src="https://github.com/user-attachments/assets/3ff8404b-1184-4a67-aa41-26568f888412" />

For reference: https://github.com/0xPolygon/kurtosis-polygon-pos/actions/runs/13522504224/job/37786648024?pr=74#step:6:2293