### PR TITLE
fix: only import package when needed

### DIFF
--- a/main.star
+++ b/main.star
@@ -1,7 +1,3 @@
-ethereum_package = import_module(
-    "github.com/ethpandaops/ethereum-package/main.star@4.4.0"
-)
-
 account_util = import_module(
     "./src/prelaunch_data_generator/genesis_constants/account.star"
 )
@@ -262,7 +258,7 @@ def deploy_local_l1(plan, ethereum_args, preregistered_validator_keys_mnemonic):
     }
 
     # Deploy the ethereum package.
-    l1 = ethereum_package.run(plan, ethereum_args)
+    l1 = import_module(constants.ETHEREUM_PACKAGE).run(plan, ethereum_args)
     plan.print(l1)
     if len(l1.all_participants) < 1:
         fail("The L1 package did not start any participants.")

--- a/src/additional_services/prometheus_grafana.star
+++ b/src/additional_services/prometheus_grafana.star
@@ -1,9 +1,4 @@
-prometheus_package = import_module(
-    "github.com/kurtosis-tech/prometheus-package/main.star"
-)
-grafana_package = import_module(
-    "github.com/kurtosis-tech/grafana-package/main.star@cc66468b167d16c0fc7153980be5b67550be01be"
-)
+constants = import_module("../package_io/constants.star")
 contract_util = import_module("../contracts/util.star")
 el_cl_launcher = import_module("../el_cl_launcher.star")
 
@@ -148,7 +143,7 @@ def launch(
 
     metrics_jobs = get_metrics_jobs(plan)
 
-    prometheus_url = prometheus_package.run(
+    prometheus_url = import_module(constants.PROMETHEUS_PACKAGE).run(
         plan,
         metrics_jobs,
         name="prometheus",
@@ -166,7 +161,7 @@ def launch(
         src=GRAFANA_DASHBOARDS, name="grafana-dashboards"
     )
 
-    grafana_package.run(
+    import_module(constants.GRAFANA_PACKAGE).run(
         plan,
         prometheus_url,
         name="grafana",

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -28,8 +28,8 @@ ADDITIONAL_SERVICES = struct(
 
 # Package dependencies.
 ETHEREUM_PACKAGE = "github.com/ethpandaops/ethereum-package/main.star@4.4.0"
-PROMETHEUS_PACKAGE = "github.com/kurtosis-tech/prometheus-package/main.star@f5ce159"
-GRAFANA_PACKAGE = "github.com/kurtosis-tech/grafana-package/main.star@cc66468"
+PROMETHEUS_PACKAGE = "github.com/kurtosis-tech/prometheus-package/main.star@f5ce159aec728898e3deb827f6b921f8ecfc527f"
+GRAFANA_PACKAGE = "github.com/kurtosis-tech/grafana-package/main.star@cc66468b167d16c0fc7153980be5b67550be01be"
 
 DEFAULT_L1_CHAIN_ID = "3151908"  # 0x301824
 DEFAULT_EL_CHAIN_ID = "4927"

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -26,6 +26,11 @@ ADDITIONAL_SERVICES = struct(
     tx_spammer="tx_spammer",
 )
 
+# Package dependencies.
+ETHEREUM_PACKAGE = "github.com/ethpandaops/ethereum-package/main.star@4.4.0"
+PROMETHEUS_PACKAGE = "github.com/kurtosis-tech/prometheus-package/main.star"
+GRAFANA_PACKAGE = "github.com/kurtosis-tech/grafana-package/main.star@cc66468b167d16c0fc7153980be5b67550be01be"
+
 DEFAULT_L1_CHAIN_ID = "3151908"  # 0x301824
 DEFAULT_EL_CHAIN_ID = "4927"
 DEFAULT_CL_CHAIN_ID = "heimdall-4927"  # Follows the standard "heimdall-<el_chain_id>".

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -28,8 +28,8 @@ ADDITIONAL_SERVICES = struct(
 
 # Package dependencies.
 ETHEREUM_PACKAGE = "github.com/ethpandaops/ethereum-package/main.star@4.4.0"
-PROMETHEUS_PACKAGE = "github.com/kurtosis-tech/prometheus-package/main.star"
-GRAFANA_PACKAGE = "github.com/kurtosis-tech/grafana-package/main.star@cc66468b167d16c0fc7153980be5b67550be01be"
+PROMETHEUS_PACKAGE = "github.com/kurtosis-tech/prometheus-package/main.star@f5ce159"
+GRAFANA_PACKAGE = "github.com/kurtosis-tech/grafana-package/main.star@cc66468"
 
 DEFAULT_L1_CHAIN_ID = "3151908"  # 0x301824
 DEFAULT_EL_CHAIN_ID = "4927"


### PR DESCRIPTION
## Description

Kurtosis will always attempt to pull prometheus and grafana packages, even if the `prometheus_grafana` additional service is not specified in the configuration... Our package should only pull package dependencies if needed.

Related issue: https://0xpolygon.slack.com/archives/C048P4UC7SL/p1741184430796209?thread_ts=1741181961.997209&cid=C048P4UC7SL