### PR TITLE
feat: bump from erigon `2.61.0` to `2.61.3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ polygon_pos_package:
       # Defaults by client:
       # - bor: "0xpolygon/bor:2.0.0"
       # - bor-modified-for-heimdall-v2: "leovct/bor-modified-for-heimdall-v2:32e26a4"
-      # - erigon: TBD
+      # - erigon: "erigontech/erigon:v2.61.3"
       el_image: 0xpolygon/bor:2.0.0
 
       # The log level string that this participant's EL client should log at.

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -9,7 +9,7 @@ DEFAULT_POS_VALIDATOR_CONFIG_GENERATOR_IMAGE = "leovct/pos-validator-config-gene
 DEFAULT_EL_IMAGES = {
     constants.EL_TYPE.bor: "0xpolygon/bor:2.0.0",
     constants.EL_TYPE.bor_modified_for_heimdall_v2: "leovct/bor-modified-for-heimdall-v2:32e26a4",  # There is no official image yet.
-    constants.EL_TYPE.erigon: "erigontech/erigon:v2.61.0",
+    constants.EL_TYPE.erigon: "erigontech/erigon:v2.61.3",
 }
 
 DEFAULT_CL_IMAGES = {


### PR DESCRIPTION
New erigon release: https://github.com/erigontech/erigon/releases/tag/v2.61.3