### PR TITLE
README: use default el chain id in params.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ polygon_pos_package:
     # The EL network id.
     # Default: "4927"
     # Note: it must be a string!
-    el_chain_id: ""
+    el_chain_id: 4927
     # The number of seconds per block on the EL chain.
     # Default: 2
     el_block_interval_seconds: 2

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ polygon_pos_package:
     # The EL network id.
     # Default: "4927"
     # Note: it must be a string!
-    el_chain_id: 4927
+    el_chain_id: "4927"
     # The number of seconds per block on the EL chain.
     # Default: 2
     el_block_interval_seconds: 2


### PR DESCRIPTION
The default `params.yml` I used from the readme doesn't have a default EL chain id which leads to this error:
```
Evaluation error: fail: CL chain id must follow the standard "heimdall-<el_chain_id>". Expected "heimdall-" but got: "heimdall-4927".
```

Might be useful to have it in readme for first time users. 