### PR TITLE
chore: update contract deployers and genesis builder images names

### DIFF
--- a/.github/tests/all.yml
+++ b/.github/tests/all.yml
@@ -28,8 +28,8 @@ polygon_pos_package:
       cl_type: heimdall
       is_validator: false
   setup_images:
-    contract_deployer: leovct/pos-contract-deployer:node-16
-    el_genesis_builder: leovct/pos-el-genesis-builder:node-16
+    contract_deployer: leovct/pos-contract-deployer-node-16:c4d8e12
+    el_genesis_builder: leovct/pos-el-genesis-builder:96a19dd
     validator_config_generator: leovct/pos-validator-config-generator:1.2.0-0.1.9
   network_params:
     ## Validators parameters.

--- a/.github/tests/contract-deployer-node-16.yml
+++ b/.github/tests/contract-deployer-node-16.yml
@@ -1,3 +1,3 @@
 polygon_pos_package:
   setup_images:
-    contract_deployer: leovct/pos-contract-deployer:node-16
+    contract_deployer: leovct/pos-contract-deployer-node-16:c4d8e12

--- a/.github/tests/contract-deployer-node-20.yml
+++ b/.github/tests/contract-deployer-node-20.yml
@@ -1,3 +1,3 @@
 polygon_pos_package:
   setup_images:
-    contract_deployer: leovct/pos-contract-deployer:node-20
+    contract_deployer: leovct/pos-contract-deployer-node-20:4a361e7

--- a/README.md
+++ b/README.md
@@ -297,11 +297,11 @@ polygon_pos_package:
   # Images for contract deployment and configuration.
   setup_images:
     # Image used to deploy MATIC contracts to L1.
-    # Default: "leovct/pos-contract-deployer:node-16"
-    contract_deployer: leovct/pos-contract-deployer:node-16
+    # Default: "leovct/pos-contract-deployer-node-16:c4d8e12"
+    contract_deployer: leovct/pos-contract-deployer-node-16:c4d8e12
     # Image used to create the L2 EL genesis file.
-    # Default: "leovct/pos-el-genesis-builder:node-16"
-    el_genesis_builder: leovct/pos-el-genesis-builder:node-16
+    # Default: "leovct/pos-el-genesis-builder:96a19dd"
+    el_genesis_builder: leovct/pos-el-genesis-builder:96a19dd
     # Image used to generate L2 CL/EL validators configurations.
     # Default: "leovct/pos-validator-config-generator:1.2.0-0.1.9"
     validator_config_generator: leovct/pos-validator-config-generator:1.2.0-0.1.9

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,12 +7,14 @@
 - [Docker Hub](https://hub.docker.com/r/leovct/bor-modified-for-heimdall-v2)
 
 ```bash
-git clone --branch heimdall-v2 git@github.com:maticnetwork/bor.git
+bor_branch="heimdall-v2"
+bor_commit_sha="32e26a4" # 18/03/2025
+image_name="leovct/bor-modified-for-heimdall-v2:${bor_commit_sha}"
+git clone --branch "${bor_branch}" git@github.com:maticnetwork/bor.git
 pushd bor
-tag="32e26a4" # 18/03/2025
-git checkout "${tag}"
-docker build --tag "leovct/bor-modified-for-heimdall-v2:${tag}" .
-docker push "leovct/bor-modified-for-heimdall-v2:${tag}"
+git checkout "${bor_commit_sha}"
+docker build --tag "${image_name}" .
+docker push "${image_name}"
 popd
 ```
 
@@ -20,16 +22,38 @@ popd
 
 ### Polygon PoS Contract Deployer
 
-- [Docker Hub](https://hub.docker.com/r/leovct/pos-contract-deployer)
+#### Node 16
+
+- [Docker Hub](https://hub.docker.com/r/leovct/pos-contract-deployer-node-16)
 
 ```bash
-# node-16
-docker build --tag leovct/pos-contract-deployer:node-16 --file pos-contract-deployer-node-16.Dockerfile .
-docker push leovct/pos-contract-deployer:node-16
+matic_contracts_branch="mardizzone/node-16"
+matic_contracts_commit_sha="c4d8e12" # 06/12/2023
+image_name="leovct/pos-contract-deployer-node-16:${matic_contracts_commit_sha}"
+docker build \
+  --build-arg MATIC_CONTRACTS_BRANCH="${matic_contracts_branch}" \
+  --build-arg MATIC_CONTRACTS_TAG_OR_COMMIT_SHA="${matic_contracts_commit_sha}" \
+  --tag "${image_name}" \
+  --file pos-contract-deployer-node-16.Dockerfile \
+  .
+docker push "${image_name}"
+```
 
-# node-20
-docker build --tag leovct/pos-contract-deployer:node-20 --file pos-contract-deployer-node-20.Dockerfile .
-docker push leovct/pos-contract-deployer:node-20
+#### Node 20
+
+- [Docker Hub](https://hub.docker.com/r/leovct/pos-contract-deployer-node-20)
+
+```bash
+pos_contracts_branch="arya/matic-cli/pos-1869"
+pos_contracts_commit_sha="4a361e7" # 20/01/2025
+image_name="leovct/pos-contract-deployer-node-20:${pos_contracts_commit_sha}"
+docker build \
+  --build-arg POS_CONTRACTS_BRANCH="${pos_contracts_branch}" \
+  --build-arg POS_CONTRACTS_TAG_OR_COMMIT_SHA="${pos_contracts_commit_sha}" \
+  --tag "${image_name}" \
+  --file pos-contract-deployer-node-20.Dockerfile \
+  .
+docker push "${image_name}"
 ```
 
 ### Polygon PoS EL Genesis Builder
@@ -37,8 +61,16 @@ docker push leovct/pos-contract-deployer:node-20
 - [Docker Hub](https://hub.docker.com/r/leovct/pos-el-genesis-builder)
 
 ```bash
-docker build --tag leovct/pos-el-genesis-builder:node-16 --file pos-el-genesis-builder.Dockerfile .
-docker push leovct/pos-el-genesis-builder:node-16
+genesis_contracts_branch="master"
+genesis_contracts_commit_sha="96a19dd" # 08/01/2025
+image_name="leovct/pos-el-genesis-builder:${genesis_contracts_commit_sha}"
+docker build \
+  --build-arg GENESIS_CONTRACTS_BRANCH="${genesis_contracts_branch}" \
+  --build-arg GENESIS_CONTRACTS_TAG_OR_COMMIT_SHA="${genesis_contracts_commit_sha}" \
+  --tag "${image_name}" \
+  --file pos-el-genesis-builder.Dockerfile \
+  .
+docker push "${image_name}"
 ```
 
 ### Polygon PoS Validator Config Generator
@@ -48,12 +80,12 @@ docker push leovct/pos-el-genesis-builder:node-16
 ```bash
 heimdall_version="1.2.0" # 29/01/2025
 heimdall_v2_version="0.1.9" # 18/03/2025
-tag="${heimdall_version}-${heimdall_v2_version}"
+image_name="leovct/pos-validator-config-generator:${heimdall_version}-${heimdall_v2_version}"
 docker build \
   --build-arg HEIMDALL_VERSION="${heimdall_version}" \
   --build-arg HEIMDALL_V2_VERSION="${heimdall_v2_version}" \
-  --tag "leovct/pos-validator-config-generator:${tag}" \
+  --tag "${image_name}" \
   --file pos-validator-config-generator.Dockerfile \
   .
-docker push "leovct/pos-validator-config-generator:${tag}"
+docker push "${image_name}"
 ```

--- a/docker/pos-contract-deployer-node-16.Dockerfile
+++ b/docker/pos-contract-deployer-node-16.Dockerfile
@@ -2,12 +2,12 @@ FROM node:16-bookworm
 LABEL description="Polygon PoS contracts deployment image (node-16)"
 LABEL author="devtools@polygon.technology"
 
+# 06/12/2023
+ARG MATIC_CONTRACTS_BRANCH="mardizzone/node-16"
+ARG MATIC_CONTRACTS_TAG_OR_COMMIT_SHA="c4d8e12"
+
 ENV TRUFFLE_VERSION="5.11.5"
 ENV DEFAULT_EL_CHAIN_ID="4927"
-
-# 06/12/2023
-ENV MATIC_CONTRACTS_BRANCH="mardizzone/node-16"
-ENV MATIC_CONTRACTS_TAG_OR_COMMIT_SHA="c4d8e12"
 
 # Prepare MATIC smart contracts for deployment by compiling them.
 # For reference: https://github.com/maticnetwork/contracts/tree/v0.3.11/deploy-migrations

--- a/docker/pos-contract-deployer-node-16.Dockerfile
+++ b/docker/pos-contract-deployer-node-16.Dockerfile
@@ -2,7 +2,12 @@ FROM node:16-bookworm
 LABEL description="Polygon PoS contracts deployment image (node-16)"
 LABEL author="devtools@polygon.technology"
 
+ENV TRUFFLE_VERSION="5.11.5"
 ENV DEFAULT_EL_CHAIN_ID="4927"
+
+# 06/12/2023
+ENV MATIC_CONTRACTS_BRANCH="mardizzone/node-16"
+ENV MATIC_CONTRACTS_TAG_OR_COMMIT_SHA="c4d8e12"
 
 # Prepare MATIC smart contracts for deployment by compiling them.
 # For reference: https://github.com/maticnetwork/contracts/tree/v0.3.11/deploy-migrations
@@ -14,9 +19,9 @@ RUN apt-get update \
   && apt-get install --yes --no-install-recommends jq \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
-  && npm install --global truffle@5.11.5 \
-  && git clone --branch mardizzone/node-16 https://github.com/maticnetwork/contracts.git . \
-  && git checkout c4d8e12 \
+  && npm install --global truffle@${TRUFFLE_VERSION} \
+  && git clone --branch ${MATIC_CONTRACTS_BRANCH} https://github.com/maticnetwork/contracts.git . \
+  && git checkout ${MATIC_CONTRACTS_TAG_OR_COMMIT_SHA} \
   && npm install \
-  && npm run template:process -- --bor-chain-id "${DEFAULT_EL_CHAIN_ID}" \
+  && npm run template:process -- --bor-chain-id ${DEFAULT_EL_CHAIN_ID} \
   && truffle compile

--- a/docker/pos-contract-deployer-node-20.Dockerfile
+++ b/docker/pos-contract-deployer-node-20.Dockerfile
@@ -2,7 +2,12 @@ FROM node:20-bookworm
 LABEL description="Polygon PoS contracts deployment image (node-20)"
 LABEL author="devtools@polygon.technology"
 
+ENV FOUNDRY_VERSION="stable"
 ENV DEFAULT_EL_CHAIN_ID="4927"
+
+# 20/01/2025
+ENV POS_CONTRACTS_BRANCH="arya/matic-cli/pos-1869"
+ENV POS_CONTRACTS_TAG_OR_COMMIT_SHA="4a361e7"
 
 # Prepare Polygon PoS smart contracts for deployment by compiling them.
 # For reference: https://github.com/0xPolygon/pos-contracts
@@ -16,14 +21,14 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   # Install foundry (stable - 20/12/2024).
   && curl --silent --location --proto "=https" https://foundry.paradigm.xyz | bash \
-  && /root/.foundry/bin/foundryup --install "stable" \
+  && /root/.foundry/bin/foundryup --install ${FOUNDRY_VERSION} \
   && cp /root/.foundry/bin/* /usr/local/bin \
   # Prepare pos contracts.
-  && git clone --branch arya/matic-cli/pos-1869 https://github.com/0xPolygon/pos-contracts . \
-  && git checkout 4a361e7 \
+  && git clone --branch ${POS_CONTRACTS_BRANCH} https://github.com/0xPolygon/pos-contracts . \
+  && git checkout ${POS_CONTRACTS_TAG_OR_COMMIT_SHA} \
   # Remove [etherscan] section from foundry.toml
   && sed -i '/^\[etherscan\]/,/^$/d' foundry.toml \
   && npm install \
-  && npm run template:process -- --bor-chain-id "${DEFAULT_EL_CHAIN_ID}" \
+  && npm run template:process -- --bor-chain-id ${DEFAULT_EL_CHAIN_ID} \
   && npm run generate:interfaces \
   && forge build

--- a/docker/pos-contract-deployer-node-20.Dockerfile
+++ b/docker/pos-contract-deployer-node-20.Dockerfile
@@ -2,12 +2,12 @@ FROM node:20-bookworm
 LABEL description="Polygon PoS contracts deployment image (node-20)"
 LABEL author="devtools@polygon.technology"
 
+# 20/01/2025
+ARG POS_CONTRACTS_BRANCH="arya/matic-cli/pos-1869"
+ARG POS_CONTRACTS_TAG_OR_COMMIT_SHA="4a361e7"
+
 ENV FOUNDRY_VERSION="stable"
 ENV DEFAULT_EL_CHAIN_ID="4927"
-
-# 20/01/2025
-ENV POS_CONTRACTS_BRANCH="arya/matic-cli/pos-1869"
-ENV POS_CONTRACTS_TAG_OR_COMMIT_SHA="4a361e7"
 
 # Prepare Polygon PoS smart contracts for deployment by compiling them.
 # For reference: https://github.com/0xPolygon/pos-contracts

--- a/docker/pos-el-genesis-builder.Dockerfile
+++ b/docker/pos-el-genesis-builder.Dockerfile
@@ -16,13 +16,13 @@ FROM node:16-bookworm
 LABEL description="MATIC (Polygon PoS) genesis builder image"
 LABEL author="devtools@polygon.technology"
 
+# 08/01/2025
+ARG GENESIS_CONTRACTS_BRANCH="master"
+ARG GENESIS_CONTRACTS_TAG_OR_COMMIT_SHA="96a19dd"
+
 ENV TRUFFLE_VERSION="5.11.5"
 ENV DEFAULT_EL_CHAIN_ID="4927"
 ENV DEFAULT_CL_CHAIN_ID="heimdall-4927"
-
-# 08/01/2025
-ENV GENESIS_CONTRACTS_BRANCH="master"
-ENV GENESIS_CONTRACTS_TAG_OR_COMMIT_SHA="96a19dd"
 
 COPY --from=soldity-builder /opt/solidity/build/solc /usr/local/bin/
 

--- a/docker/pos-el-genesis-builder.Dockerfile
+++ b/docker/pos-el-genesis-builder.Dockerfile
@@ -5,7 +5,7 @@ LABEL author="devtools@polygon.technology"
 WORKDIR /opt/solidity
 RUN apt-get update \
   && apt-get install --yes cmake libboost-all-dev z3 cvc4 git gcc g++ \
-  && git clone --branch v0.5.17 https://github.com/ethereum/solidity.git . \
+  && git clone --branch v0.5.17 --depth 1 https://github.com/ethereum/solidity.git . \
   && mkdir build \
   && cd build \
   && cmake .. \
@@ -16,8 +16,13 @@ FROM node:16-bookworm
 LABEL description="MATIC (Polygon PoS) genesis builder image"
 LABEL author="devtools@polygon.technology"
 
+ENV TRUFFLE_VERSION="5.11.5"
 ENV DEFAULT_EL_CHAIN_ID="4927"
 ENV DEFAULT_CL_CHAIN_ID="heimdall-4927"
+
+# 08/01/2025
+ENV GENESIS_CONTRACTS_BRANCH="master"
+ENV GENESIS_CONTRACTS_TAG_OR_COMMIT_SHA="96a19dd"
 
 COPY --from=soldity-builder /opt/solidity/build/solc /usr/local/bin/
 
@@ -27,17 +32,16 @@ RUN apt-get update \
   && apt-get install --yes jq \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
-  && npm install --global truffle@5.11.5 \
-  && git clone https://github.com/maticnetwork/genesis-contracts.git . \
-  && git checkout 96a19dd \
+  && npm install --global truffle@${TRUFFLE_VERSION} \
+  && git clone --branch ${GENESIS_CONTRACTS_BRANCH} https://github.com/maticnetwork/genesis-contracts.git . \
+  && git checkout ${GENESIS_CONTRACTS_TAG_OR_COMMIT_SHA} \
   && git submodule init \
   && git submodule update \
   && npm install \
   && cd matic-contracts \
-  && git checkout mardizzone/node-16 \
   && npm install \
-  && npm run template:process -- --bor-chain-id "${DEFAULT_EL_CHAIN_ID}" \
+  && npm run template:process -- --bor-chain-id ${DEFAULT_EL_CHAIN_ID} \
   && truffle compile \
   && cd .. \
-  && node generate-borvalidatorset.js --bor-chain-id "${DEFAULT_EL_CHAIN_ID}" --heimdall-chain-id "${DEFAULT_CL_CHAIN_ID}" \
+  && node generate-borvalidatorset.js --bor-chain-id ${DEFAULT_EL_CHAIN_ID} --heimdall-chain-id ${DEFAULT_CL_CHAIN_ID} \
   && truffle compile

--- a/src/contracts/contract_deployer.star
+++ b/src/contracts/contract_deployer.star
@@ -110,17 +110,21 @@ def _format_validator_accounts(accounts):
 
 
 def _determine_contract_deployer_config_filepath(contract_deployer_image):
-    # The contract deployer image follows the standard: leovct/pos-contract-deployer:<node-version>
-    # where the version can either be "node-16" or "node-20".
-    result = contract_deployer_image.split(":")
+    # The contract deployer image follows the standard: leovct/pos-contract-deployer-<node-version>:<tag>
+    # where the node version can either be "node-16" or "node-20".
+    result = contract_deployer_image.removeprefix(
+        "leovct/pos-contract-deployer-"
+    ).split(
+        ":"
+    )  # ["<node-version>", "tag"]
     if len(result) != 2:
         fail(
-            'The contract deployer image does not follow the standard "leovct/pos-contract-deployer:<node-version>": {}'.format(
+            'The contract deployer image does not follow the standard "leovct/pos-contract-deployer-<node-version>:<tag>": {}'.format(
                 contract_deployer_image
             )
         )
 
-    node_version = result[1]
+    node_version = result[0]
     supported_versions = ["node-16", "node-20"]
     if node_version not in supported_versions:
         fail(

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2,8 +2,8 @@ constants = import_module("./constants.star")
 math = import_module("../math/math.star")
 sanity_check = import_module("./sanity_check.star")
 
-DEFAULT_POS_CONTRACT_DEPLOYER_IMAGE = "leovct/pos-contract-deployer:node-16"
-DEFAULT_POS_EL_GENESIS_BUILDER_IMAGE = "leovct/pos-el-genesis-builder:node-16"
+DEFAULT_POS_CONTRACT_DEPLOYER_IMAGE = "leovct/pos-contract-deployer-node-16:c4d8e12"
+DEFAULT_POS_EL_GENESIS_BUILDER_IMAGE = "leovct/pos-el-genesis-builder:96a19dd"
 DEFAULT_POS_VALIDATOR_CONFIG_GENERATOR_IMAGE = "leovct/pos-validator-config-generator:1.2.0-0.1.9"  # Based on 0xpolygon/heimdall:1.2.0 and 0xpolygon/heimdall-v2:0.1.9.
 
 DEFAULT_EL_IMAGES = {


### PR DESCRIPTION
## Description

Our utility images rely on the following repositories:

- https://github.com/maticnetwork/contracts
- https://github.com/0xPolygon/pos-contracts
- https://github.com/maticnetwork/genesis-contracts

Since there have been lots of changes in these repositories, it would be great to:

1) Think how to better label/tag images to make it easier to track which commit/tag it targets.
2) Bump to the latest commits (pos-contracts and genesis-contracts)

https://github.com/0xPolygon/devtools/issues/166

This PR addresses the first point.

- Update docker images to support branch and tag or commit sha - it will be easier to maintain and upgrade.
- Release new images and deprecate old images:
  - `leovct/pos-contract-deployer:node-16` => `leovct/pos-contract-deployer-node-16:c4d8e12`
  - `leovct/pos-contract-deployer:node-20` => `leovct/pos-contract-deployer-node-20:4a361e7`
  - `leovct/pos-el-genesis-builder:node-16` => `leovct/pos-el-genesis-builder:96a19dd`
- Update the logic to determine the contract deployer config filepath since the contract deployer image name has changed.
