### PR TITLE
ci: test `bor:2.0.2-beta`

### DIFF
--- a/.github/tests/heimdall-bor-beta-multi-validators.yml
+++ b/.github/tests/heimdall-bor-beta-multi-validators.yml
@@ -1,0 +1,34 @@
+polygon_pos_package:
+  participants:
+    # validators
+    - cl_type: heimdall
+      cl_log_level: debug
+      el_type: bor
+      el_log_level: trace
+      is_validator: true
+      count: 2
+    - cl_type: heimdall
+      cl_log_level: debug
+      el_type: bor
+      el_image: 0xpolygon/bor:2.0.2-beta
+      el_log_level: trace
+      is_validator: true
+      count: 2
+    
+
+    # rpcs
+    - cl_type: heimdall
+      el_type: bor
+      is_validator: false
+      count: 2
+    - cl_type: heimdall
+      el_type: bor
+      el_image: 0xpolygon/bor:2.0.2-beta
+      is_validator: false
+      count: 2
+    # There is an issue with erigon rpcs.
+    # https://github.com/0xPolygon/kurtosis-polygon-pos/issues/26
+    # - cl_type: heimdall
+    #   el_type: erigon
+    #   is_validator: false
+    #   count: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.yml
+/*.yml
 tmp/
 
 # temporary files


### PR DESCRIPTION
## Description

Test the [new bor beta release](https://github.com/maticnetwork/bor/releases/tag/v2.0.2-beta) along with the latest bor release.