### PR TITLE
chore: bump to `leovct/bor:1a6957c`

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ polygon_pos_package:
       # Leave blank to use the default image for the client type.
       # Defaults by client:
       # - bor: "0xpolygon/bor:2.0.1"
-      # - bor-modified-for-heimdall-v2: "leovct/bor-modified-for-heimdall-v2:32e26a4"
+      # - bor-modified-for-heimdall-v2: "leovct/bor:1a6957c"
       # - erigon: "erigontech/erigon:v2.61.3"
       el_image: 0xpolygon/bor:2.0.1
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,12 +4,12 @@
 
 ### Bor Modified for Heimdall v2
 
-- [Docker Hub](https://hub.docker.com/r/leovct/bor-modified-for-heimdall-v2)
+- [Docker Hub](https://hub.docker.com/r/leovct/bor)
 
 ```bash
 bor_branch="heimdall-v2"
-bor_commit_sha="32e26a4" # 2025/03/18
-image_name="leovct/bor-modified-for-heimdall-v2:${bor_commit_sha}"
+bor_commit_sha="1a6957c" # 2025/03/27
+image_name="leovct/bor:${bor_commit_sha}"
 git clone --branch "${bor_branch}" git@github.com:maticnetwork/bor.git
 pushd bor
 git checkout "${bor_commit_sha}"

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -8,7 +8,7 @@ DEFAULT_POS_VALIDATOR_CONFIG_GENERATOR_IMAGE = "leovct/pos-validator-config-gene
 
 DEFAULT_EL_IMAGES = {
     constants.EL_TYPE.bor: "0xpolygon/bor:2.0.1",
-    constants.EL_TYPE.bor_modified_for_heimdall_v2: "leovct/bor-modified-for-heimdall-v2:32e26a4",  # There is no official image yet.
+    constants.EL_TYPE.bor_modified_for_heimdall_v2: "leovct/bor:1a6957c",  # There is no official image yet.
     constants.EL_TYPE.erigon: "erigontech/erigon:v2.61.3",
 }
 


### PR DESCRIPTION
## Description

- Bump to the latest version of bor modified for heimdall-v2.
- Use a shorter name.
