### PR TITLE
chore: remove `bor_modified_for_heimdall_v2` el type

### DIFF
--- a/.github/tests/heimdall-v2-bor-multi-validators.yml
+++ b/.github/tests/heimdall-v2-bor-multi-validators.yml
@@ -3,14 +3,14 @@ polygon_pos_package:
     # validators
     - cl_type: heimdall-v2
       cl_log_level: trace
-      el_type: bor-modified-for-heimdall-v2
+      el_type: bor
       el_log_level: trace
       is_validator: true
       count: 4
 
     # rpcs
     - cl_type: heimdall-v2
-      el_type: bor-modified-for-heimdall-v2
+      el_type: bor
       is_validator: false
       count: 2
     # For now erigon doesn't support heimdall-v2.

--- a/.github/tests/heimdall-v2-bor-single-validator.yml
+++ b/.github/tests/heimdall-v2-bor-single-validator.yml
@@ -3,13 +3,13 @@ polygon_pos_package:
     # validators
     - cl_type: heimdall-v2
       cl_log_level: trace
-      el_type: bor-modified-for-heimdall-v2
+      el_type: bor
       el_log_level: trace
       is_validator: true
 
     # rpcs
     - cl_type: heimdall-v2
-      el_type: bor-modified-for-heimdall-v2
+      el_type: bor
       is_validator: false
       count: 2
     # For now erigon doesn't support heimdall-v2.

--- a/README.md
+++ b/README.md
@@ -244,14 +244,14 @@ polygon_pos_package:
   participants:
     - ## Execution Layer (EL) specific flags.
       # The type of EL client that should be started.
-      # Valid values are: "bor", "bor-modified-for-heimdall-v2", "erigon"
+      # Valid values are: "bor", "erigon"
       el_type: bor
 
       # The docker image that should be used for the EL client.
       # Leave blank to use the default image for the client type.
       # Defaults by client:
       # - bor: "0xpolygon/bor:2.0.1"
-      # - bor-modified-for-heimdall-v2: "leovct/bor:1a6957c"
+      # - bor modified for heimdall-v2: "leovct/bor:1a6957c"
       # - erigon: "erigontech/erigon:v2.61.3"
       el_image: 0xpolygon/bor:2.0.1
 

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -37,9 +37,6 @@ def launch(
         "bor": {
             "launch_method": bor.launch,
         },
-        "bor-modified-for-heimdall-v2": {
-            "launch_method": bor.launch,
-        },
         "erigon": {
             "launch_method": erigon.launch,
         },

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -191,19 +191,6 @@ def _parse_participants(participants):
         # Create a mutable copy of participant.
         p = dict(p)
 
-        # Set default EL image based on `el_type` if provided.
-        el_type = p.get("el_type", "")
-        el_image = p.get("el_image", "")
-        if el_type and not el_image:
-            if el_type == constants.EL_TYPE.bor:
-                p["el_image"] = DEFAULT_EL_IMAGES[constants.EL_TYPE.bor]
-            if el_type == constants.EL_TYPE.bor_modified_for_heimdall_v2:
-                p["el_image"] = DEFAULT_EL_IMAGES[
-                    constants.EL_TYPE.bor_modified_for_heimdall_v2
-                ]
-            elif el_type == constants.EL_TYPE.erigon:
-                p["el_image"] = DEFAULT_EL_IMAGES[constants.EL_TYPE.erigon]
-
         # Set default CL image based on `cl_type` if provided
         cl_type = p.get("cl_type", "")
         cl_image = p.get("cl_image", "")
@@ -212,6 +199,26 @@ def _parse_participants(participants):
                 p["cl_image"] = DEFAULT_CL_IMAGES[constants.CL_TYPE.heimdall]
             elif cl_type == constants.CL_TYPE.heimdall_v2:
                 p["cl_image"] = DEFAULT_CL_IMAGES[constants.CL_TYPE.heimdall_v2]
+            else:
+                fail("Invalid CL client type: '{}'.".format(cl_type))
+
+        # Set default EL image based on `el_type` if provided.
+        el_type = p.get("el_type", "")
+        el_image = p.get("el_image", "")
+        if el_type and not el_image:
+            if el_type == constants.EL_TYPE.bor:
+                if cl_type == constants.CL_TYPE.heimdall:
+                    p["el_image"] = DEFAULT_EL_IMAGES[constants.EL_TYPE.bor]
+                elif cl_type == constants.CL_TYPE.heimdall_v2:
+                    p["el_image"] = DEFAULT_EL_IMAGES[
+                        constants.EL_TYPE.bor_modified_for_heimdall_v2
+                    ]
+                else:
+                    fail("Invalid CL client type: '{}'.".format(cl_type))
+            elif el_type == constants.EL_TYPE.erigon:
+                p["el_image"] = DEFAULT_EL_IMAGES[constants.EL_TYPE.erigon]
+            else:
+                fail("Invalid EL client type: '{}'.".format(el_type))
 
         # Fill in any missing fields with default values.
         for k, v in DEFAULT_POLYGON_POS_PARTICIPANT.items():

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -39,14 +39,23 @@ POLYGON_POS_PARAMS = {
     ],
 }
 
+VALID_CL_CLIENTS = [constants.CL_TYPE.heimdall, constants.CL_TYPE.heimdall_v2]
+VALID_EL_CLIENTS = [constants.EL_TYPE.bor, constants.EL_TYPE.erigon]
 VALID_CLIENT_COMBINATIONS = {
     constants.CL_TYPE.heimdall: [
         constants.EL_TYPE.bor,
-        constants.EL_TYPE.bor_modified_for_heimdall_v2,
         constants.EL_TYPE.erigon,
     ],
-    constants.CL_TYPE.heimdall_v2: [constants.EL_TYPE.bor_modified_for_heimdall_v2],
+    constants.CL_TYPE.heimdall_v2: [constants.EL_TYPE.bor],
 }
+
+VALID_LOG_LEVELS = [
+    constants.LOG_LEVEL.error,
+    constants.LOG_LEVEL.warn,
+    constants.LOG_LEVEL.info,
+    constants.LOG_LEVEL.debug,
+    constants.LOG_LEVEL.trace,
+]
 
 DEV_PARAMS = [
     "should_deploy_l1",  # boolean
@@ -183,18 +192,8 @@ def validate_chain_ids(cl_chain_id, el_chain_id):
 
 
 def _validate_participant(p):
-    _validate_str(
-        p, "cl_type", [constants.CL_TYPE.heimdall, constants.CL_TYPE.heimdall_v2]
-    )
-    _validate_str(
-        p,
-        "el_type",
-        [
-            constants.EL_TYPE.bor,
-            constants.EL_TYPE.bor_modified_for_heimdall_v2,
-            constants.EL_TYPE.erigon,
-        ],
-    )
+    _validate_str(p, "cl_type", VALID_CL_CLIENTS)
+    _validate_str(p, "el_type", VALID_EL_CLIENTS)
 
     # Validate client combination.
     cl_type = p.get("cl_type")
@@ -210,15 +209,8 @@ def _validate_participant(p):
     else:
         fail('The CL client "{}" has no valid client combination.'.format(cl_type))
 
-    log_levels = [
-        constants.LOG_LEVEL.error,
-        constants.LOG_LEVEL.warn,
-        constants.LOG_LEVEL.info,
-        constants.LOG_LEVEL.debug,
-        constants.LOG_LEVEL.trace,
-    ]
-    _validate_str(p, "cl_log_level", log_levels)
-    _validate_str(p, "el_log_level", log_levels)
+    _validate_str(p, "cl_log_level", VALID_LOG_LEVELS)
+    _validate_str(p, "el_log_level", VALID_LOG_LEVELS)
 
     # Heimdall (v1) only supports "error", "info", "debug" or "none" log levels.
     # ERROR: Failed to parse default log level (pair *:trace, list *:trace): Expected either "info", "debug", "error" or "none" level, given trace


### PR DESCRIPTION
## Description

It was quite confusing for users to differentiate between `bor` and `bor-modified-for-heimdall-v2` as they rely on the same exact codebase. That's why we choose to remove this extra CL type from the parameters. Users would now use `el_type: bor` which makes things simpler.

If not defined by the user, the input parser will define the EL image to use according to the CL image.