### PR TITLE
fix: prometheus grafana l1 and l2 chain ids

### DIFF
--- a/main.star
+++ b/main.star
@@ -179,7 +179,7 @@ def run(plan, args):
             participants_count, len(validator_accounts), participants
         )
     )
-    l2_participants = el_cl_launcher.launch(
+    l2_context = el_cl_launcher.launch(
         plan,
         participants,
         polygon_pos_args,
@@ -188,13 +188,14 @@ def run(plan, args):
         l1_context.rpc_url,
         devnet_cl_type,
     )
+    l2_rpc_url = l2_context.all_participants[0].el_context.rpc_http_url
 
     # Deploy MATIC contracts to L2.
     result = contract_deployer.deploy_l2_contracts_and_synchronise_l1_state(
         plan,
         polygon_pos_args,
         l1_context.rpc_url,
-        l2_participants[0].el_context.rpc_http_url,
+        l2_rpc_url,
         admin_private_key,
         l1_contract_addresses_artifact,
     )
@@ -216,8 +217,7 @@ def run(plan, args):
             prometheus_grafana.launch(
                 plan,
                 l1_context,
-                l2_participants,
-                constants.DEFAULT_EL_CHAIN_ID,
+                l2_context,
                 l2_el_genesis_artifact,
                 contract_addresses_artifact,
             )

--- a/main.star
+++ b/main.star
@@ -5,6 +5,7 @@ blockscout = import_module("./src/additional_services/blockscout.star")
 cl_genesis_generator = import_module(
     "./src/prelaunch_data_generator/cl_genesis/cl_genesis_generator.star"
 )
+constants = import_module("./src/package_io/constants.star")
 contract_deployer = import_module("./src/contracts/contract_deployer.star")
 el_cl_launcher = import_module("./src/el_cl_launcher.star")
 el_genesis_generator = import_module(
@@ -20,7 +21,8 @@ pre_funded_accounts = import_module(
 prometheus_grafana = import_module("./src/additional_services/prometheus_grafana.star")
 tx_spammer = import_module("./src/additional_services/tx_spammer.star")
 wait = import_module("./src/wait/wait.star")
-constants = import_module("./src/package_io/constants.star")
+
+ETHEREUM_PACKAGE = "github.com/ethpandaops/ethereum-package/main.star@4.4.0"
 
 
 def run(plan, args):
@@ -272,7 +274,7 @@ def deploy_local_l1(plan, ethereum_args, preregistered_validator_keys_mnemonic):
     }
 
     # Deploy the ethereum package.
-    l1 = import_module(constants.ETHEREUM_PACKAGE).run(plan, ethereum_args)
+    l1 = import_module(ETHEREUM_PACKAGE).run(plan, ethereum_args)
     plan.print(l1)
     if len(l1.all_participants) < 1:
         fail("The L1 package did not start any participants.")

--- a/src/additional_services/prometheus_grafana.star
+++ b/src/additional_services/prometheus_grafana.star
@@ -15,7 +15,6 @@ PANOPTICHAIN_METRICS_PATH = "/metrics"
 def launch(
     plan,
     l1_context,
-    l1_chain_id,
     l2_participants,
     l2_chain_id,
     l2_el_genesis_artifact,
@@ -24,7 +23,6 @@ def launch(
     panoptichain_url = launch_panoptichain(
         plan,
         l1_context,
-        l1_chain_id,
         l2_participants,
         l2_chain_id,
         l2_el_genesis_artifact,
@@ -37,7 +35,6 @@ def launch(
 def launch_panoptichain(
     plan,
     l1_context,
-    l1_chain_id,
     l2_participants,
     l2_chain_id,
     l2_el_genesis_artifact,
@@ -86,7 +83,7 @@ def launch_panoptichain(
             "config.yml": struct(
                 template=read_file(src="../../static_files/panoptichain/config.yml"),
                 data={
-                    "l1_chain_id": l1_chain_id,
+                    "l1_chain_id": l1_context.chain_id,
                     "l2_chain_id": l2_chain_id,
                     "l1_rpcs": l1_rpcs,
                     "l2_rpcs": l2_el_rpcs,

--- a/src/additional_services/prometheus_grafana.star
+++ b/src/additional_services/prometheus_grafana.star
@@ -157,6 +157,6 @@ def launch_grafana(plan, prometheus_url):
         plan,
         prometheus_url,
         name="grafana",
-        grafana_version=GRAFANA_VERSION,
+        image=GRAFANA_IMAGE,
         grafana_dashboards_files_artifact=grafana_dashboards_files_artifact,
     )

--- a/src/additional_services/prometheus_grafana.star
+++ b/src/additional_services/prometheus_grafana.star
@@ -15,8 +15,7 @@ PANOPTICHAIN_METRICS_PATH = "/metrics"
 def launch(
     plan,
     l1_context,
-    l2_participants,
-    l2_chain_id,
+    l2_context,
     l2_el_genesis_artifact,
     contract_addresses_artifact,
 ):
@@ -50,14 +49,15 @@ def launch_panoptichain(
 
     # Retrieve L2 EL and CL urls.
     l2_el_rpcs = {
-        p.el_context.service_name: p.el_context.rpc_http_url for p in l2_participants
+        p.el_context.service_name: p.el_context.rpc_http_url
+        for p in l2_context.all_participants
     }
     l2_cl_urls = {
         p.cl_context.service_name: {
             "heimdall": p.cl_context.api_url,
             "tendermint": p.cl_context.rpc_url,
         }
-        for p in l2_participants
+        for p in l2_context.all_participants
     }
 
     # Retrieve contract addresses.
@@ -84,7 +84,7 @@ def launch_panoptichain(
                 template=read_file(src="../../static_files/panoptichain/config.yml"),
                 data={
                     "l1_chain_id": l1_context.chain_id,
-                    "l2_chain_id": l2_chain_id,
+                    "l2_chain_id": l2_context.el_chain_id,
                     "l1_rpcs": l1_rpcs,
                     "l2_rpcs": l2_el_rpcs,
                     "heimdall_urls": l2_cl_urls,

--- a/src/additional_services/prometheus_grafana.star
+++ b/src/additional_services/prometheus_grafana.star
@@ -22,20 +22,20 @@ def launch(
     panoptichain_url = launch_panoptichain(
         plan,
         l1_context,
-        l2_participants,
-        l2_chain_id,
+        l2_context,
         l2_el_genesis_artifact,
         contract_addresses_artifact,
     )
-    prometheus_url = launch_prometheus(plan, l2_participants, panoptichain_url)
+    prometheus_url = launch_prometheus(
+        plan, l2_context.all_participants, panoptichain_url
+    )
     launch_grafana(plan, prometheus_url)
 
 
 def launch_panoptichain(
     plan,
     l1_context,
-    l2_participants,
-    l2_chain_id,
+    l2_context,
     l2_el_genesis_artifact,
     contract_addresses_artifact,
 ):

--- a/src/additional_services/prometheus_grafana.star
+++ b/src/additional_services/prometheus_grafana.star
@@ -1,10 +1,10 @@
-constants = import_module("../package_io/constants.star")
 contract_util = import_module("../contracts/util.star")
-el_cl_launcher = import_module("../el_cl_launcher.star")
 
+PROMETHEUS_PACKAGE = "github.com/kurtosis-tech/prometheus-package/main.star@f5ce159aec728898e3deb827f6b921f8ecfc527f"
 PROMETHEUS_IMAGE = "prom/prometheus:v3.2.1"
 
-GRAFANA_VERSION = "11.5.3"
+GRAFANA_PACKAGE = "github.com/kurtosis-tech/grafana-package/main.star@c8ff0b52d25deb0bc4ec95971dcf25b2fca11287"
+GRAFANA_IMAGE = "grafana/grafana:11.6.0"
 GRAFANA_DASHBOARDS = "../../static_files/grafana/dashboards"
 
 PANOPTICHAIN_IMAGE = "ghcr.io/0xpolygon/panoptichain:v1.2.3"
@@ -113,7 +113,7 @@ def launch_panoptichain(
 
 def launch_prometheus(plan, l2_participants, panoptichain_url):
     metrics_jobs = generate_metrics_jobs(l2_participants, panoptichain_url)
-    return import_module(constants.PROMETHEUS_PACKAGE).run(
+    return import_module(PROMETHEUS_PACKAGE).run(
         plan,
         metrics_jobs,
         name="prometheus",
@@ -153,7 +153,7 @@ def launch_grafana(plan, prometheus_url):
     grafana_dashboards_files_artifact = plan.upload_files(
         src=GRAFANA_DASHBOARDS, name="grafana-dashboards"
     )
-    import_module(constants.GRAFANA_PACKAGE).run(
+    import_module(GRAFANA_PACKAGE).run(
         plan,
         prometheus_url,
         name="grafana",

--- a/src/contracts/util.star
+++ b/src/contracts/util.star
@@ -90,6 +90,7 @@ def get_address(
         )
 
     result = plan.run_sh(
+        name="{}-address-reader".format(contract_name),
         description="Reading '{}' contract address".format(contract_name),
         files={
             "/opt/contracts": artifact,

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -344,6 +344,7 @@ def _generate_validator_config(
 
 def _read_cl_persistent_peers(plan, cl_persistent_peers_artifact):
     result = plan.run_sh(
+        name="cl-validator-node-ids-reader",
         description="Reading CL validator node ids",
         files={
             "/opt/data": cl_persistent_peers_artifact,

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -195,8 +195,12 @@ def launch(
     # The first producer should have committed a span.
     wait.wait_for_l2_startup(plan, first_cl_context.api_url, devnet_cl_type)
 
-    # Return the L2 participants and their context.
-    return all_participants
+    # Return the L2 context.
+    return struct(
+        el_chain_id=network_params.get("el_chain_id"),
+        devnet_cl_type=devnet_cl_type,
+        all_participants=all_participants,
+    )
 
 
 def _prepare_network_data(participants):

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -26,11 +26,6 @@ ADDITIONAL_SERVICES = struct(
     tx_spammer="tx_spammer",
 )
 
-# Package dependencies.
-ETHEREUM_PACKAGE = "github.com/ethpandaops/ethereum-package/main.star@4.4.0"
-PROMETHEUS_PACKAGE = "github.com/kurtosis-tech/prometheus-package/main.star@f5ce159aec728898e3deb827f6b921f8ecfc527f"
-GRAFANA_PACKAGE = "github.com/kurtosis-tech/grafana-package/main.star@cc66468b167d16c0fc7153980be5b67550be01be"
-
 DEFAULT_L1_CHAIN_ID = "3151908"  # 0x301824
 DEFAULT_EL_CHAIN_ID = "4927"
 DEFAULT_CL_CHAIN_ID = "heimdall-4927"  # Follows the standard "heimdall-<el_chain_id>".

--- a/src/wait/wait.star
+++ b/src/wait/wait.star
@@ -3,7 +3,7 @@ constants = import_module("../package_io/constants.star")
 
 def wait_for_l1_startup(plan, cl_rpc_url):
     plan.run_sh(
-        name="wait-for-l1-startup",
+        name="l1-startup-monitor",
         description="Wait for L1 to start up - it can take up to 2 minutes",
         env_vars={
             "CL_RPC_URL": cl_rpc_url,
@@ -50,7 +50,7 @@ def wait_for_l2_startup(plan, cl_api_url, cl_type):
         )
 
     plan.run_sh(
-        name="wait-for-l2-startup",
+        name="l2-startup-monitor",
         description="Wait for L2 to start up - it can take up to 2 minutes",
         env_vars={
             "CL_RPC_URL": cl_api_url,


### PR DESCRIPTION
## Description

- Add more info into the L2 context.
- Fix an issue with L1 and L2 chain ids used in the prometheus grafana additional service.

```bash
$ yq '.networks[0]' $HOME/Downloads/dump_run_with_args_prometheus-grafana_14172485371/files/panoptichain-config/config.yml
{
  "name": "L1",
  "chain_id": "3151908"
}
```

- Update to the latest version of the grafana package.
- Clean up imports.
- Rename `plan.run_sh` services.

## Test

Deployed the package locally and made sure that:

1) prometheus ui works fine and targets are healthy
2) grafana ui works fine and panoptichain dashboard shows metrics
