### PR TITLE
ci: remove `nightly` from nightly job names

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -34,7 +34,7 @@ jobs:
           matrix=$(echo "${file_paths}" | while read -r file_path; do
             file_name=$(basename -s ".yml" "${file_path}")
             folder_name=$(basename $(dirname "${file_path}"))
-            if [[ "${folder_name}" == "tests" ]]; then
+            if [[ "${folder_name}" == "nightly" ]]; then
               job_name="${file_name}"
             else
               job_name="${folder_name}-${file_name}"


### PR DESCRIPTION
## Before

<img width="1706" alt="Screenshot 2025-04-18 at 13 02 18" src="https://github.com/user-attachments/assets/2f8401be-f6fd-43c6-8c19-a685ad8248d3" />

## After

<img width="1704" alt="Screenshot 2025-04-18 at 13 02 43" src="https://github.com/user-attachments/assets/25995ab9-6e9e-434a-99e7-51e7d873d889" />

