### PR TITLE
refactor: introduce participant kind

### DIFF
--- a/.github/tests/heimdall-bor.yml
+++ b/.github/tests/heimdall-bor.yml
@@ -1,13 +1,10 @@
 polygon_pos_package:
   participants:
-    # validators
-    - cl_type: heimdall
+    - kind: validator
+      cl_type: heimdall
       el_type: bor
-      is_validator: true
       count: 4
-
-    # rpcs
-    - cl_type: heimdall
+    - kind: rpc
+      cl_type: heimdall
       el_type: bor
-      is_validator: false
       count: 2

--- a/.github/tests/heimdall-erigon.yml
+++ b/.github/tests/heimdall-erigon.yml
@@ -1,15 +1,12 @@
 polygon_pos_package:
   participants:
-    # validators
-    - cl_type: heimdall
+    - kind: validator
+      cl_type: heimdall
       el_type: erigon
-      is_validator: true
       count: 4
-
-    # rpcs
-    - cl_type: heimdall
+    - kind: rpc
+      cl_type: heimdall
       el_type: erigon
-      is_validator: false
       count: 2
 
   network_params:

--- a/.github/tests/heimdall-v2-bor.yml
+++ b/.github/tests/heimdall-v2-bor.yml
@@ -1,13 +1,11 @@
 polygon_pos_package:
   participants:
     # validators
-    - cl_type: heimdall-v2
+    - kind: validator
+      cl_type: heimdall-v2
       el_type: bor
-      is_validator: true
       count: 4
-
-    # rpcs
-    - cl_type: heimdall-v2
+    - kind: rpc
+      cl_type: heimdall-v2
       el_type: bor
-      is_validator: false
       count: 2

--- a/.github/tests/nightly/all.yml
+++ b/.github/tests/nightly/all.yml
@@ -15,18 +15,18 @@ ethereum_package:
 # Polygon PoS package (L2) configuration.
 polygon_pos_package:
   participants:
-    - el_type: bor
+    - kind: validator
+      el_type: bor
       el_image: 0xpolygon/bor:2.0.1
       el_log_level: info
       cl_type: heimdall
       cl_image: 0xpolygon/heimdall:1.2.3
       cl_db_image: rabbitmq:4.0.6
       cl_log_level: info
-      is_validator: true
       count: 2
-    - el_type: bor
+    - kind: rpc
+      el_type: bor
       cl_type: heimdall
-      is_validator: false
   setup_images:
     contract_deployer: leovct/pos-contract-deployer-node-20:ed58f8a
     el_genesis_builder: leovct/pos-el-genesis-builder:96a19dd

--- a/.github/tests/nightly/heimdall-bor-minimal.yml
+++ b/.github/tests/nightly/heimdall-bor-minimal.yml
@@ -1,5 +1,5 @@
 polygon_pos_package:
   participants:
-    - cl_type: heimdall
+    - kind: validator
+      cl_type: heimdall
       el_type: bor
-      is_validator: true

--- a/.github/tests/nightly/heimdall-erigon-minimal.yml
+++ b/.github/tests/nightly/heimdall-erigon-minimal.yml
@@ -1,8 +1,8 @@
 polygon_pos_package:
   participants:
-    - cl_type: heimdall
+    - kind: validator
+      cl_type: heimdall
       el_type: erigon
-      is_validator: true
 
   network_params:
     cl_environment: local

--- a/.github/tests/nightly/heimdall-v2-bor-minimal.yml
+++ b/.github/tests/nightly/heimdall-v2-bor-minimal.yml
@@ -1,5 +1,5 @@
 polygon_pos_package:
   participants:
-    - cl_type: heimdall-v2
+    - kind: validator
+      cl_type: heimdall-v2
       el_type: bor
-      is_validator: true

--- a/README.md
+++ b/README.md
@@ -215,7 +215,6 @@ polygon_pos_package:
       # Valid values are:
       # - "validator": A participant responsible for validating and proposing blocks.
       # - "rpc": A participant that provides RPC endpoints for interacting with the network (e.g., querying data, sending transactions).
-      # - "stateless": A lightweight participant that does not maintain state but may serve other purposes (e.g., monitoring or relaying data).
       kind: validator
 
       ## Execution Layer (EL) specific flags.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,14 @@ ethereum_package:
 polygon_pos_package:
   # Specification of the L2 participants.
   participants:
-    - ## Execution Layer (EL) specific flags.
+    - ## Role of the participant in the network.
+      # Valid values are:
+      # - "validator": A participant responsible for validating and proposing blocks.
+      # - "rpc": A participant that provides RPC endpoints for interacting with the network (e.g., querying data, sending transactions).
+      # - "stateless": A lightweight participant that does not maintain state but may serve other purposes (e.g., monitoring or relaying data).
+      kind: validator
+
+      ## Execution Layer (EL) specific flags.
       # The type of EL client that should be started.
       # Valid values are: "bor", "erigon"
       el_type: bor
@@ -251,17 +258,13 @@ polygon_pos_package:
       # Valid values are: "error", "warn", "info", "debug", "trace"
       cl_log_level: info
 
-      # Wether to run this participant as a validator or an rpc.
-      # Default: false (run as an rpc)
-      is_validator: true
-
       # Count of nodes to spin up for this participant.
       # Default: 1
       count: 2
 
-    - el_type: bor
+    - kind: rpc
+      el_type: bor
       cl_type: heimdall
-      is_validator: false
 
   # Images for contract deployment and configuration.
   setup_images:

--- a/main.star
+++ b/main.star
@@ -205,13 +205,14 @@ def get_validator_accounts(participants):
     prefunded_accounts = prefunded_accounts_module.PREFUNDED_ACCOUNTS
 
     validator_accounts = []
-    participant_index = 0
-    for participant in participants:
-        for _ in range(participant.get("count")):
-            if participant.get("kind") == constants.PARTICIPANT_KIND.validator:
-                account = prefunded_accounts[participant_index]
+    id = 0
+    for p in participants:
+        for _ in range(p.get("count")):
+            is_validator = p.get("kind") == constants.PARTICIPANT_KIND.validator
+            if is_validator:
+                account = prefunded_accounts[id]
                 validator_accounts.append(account)
-            participant_index += 1
+            id += 1
 
     if len(validator_accounts) == 0:
         fail("There must be at least one validator among the participants!")

--- a/main.star
+++ b/main.star
@@ -208,7 +208,7 @@ def get_validator_accounts(participants):
     participant_index = 0
     for participant in participants:
         for _ in range(participant.get("count")):
-            if participant.get("is_validator"):
+            if participant.get("kind") == constants.PARTICIPANT_KIND.validator:
                 account = prefunded_accounts[participant_index]
                 validator_accounts.append(account)
             participant_index += 1

--- a/src/cl/launcher.star
+++ b/src/cl/launcher.star
@@ -28,8 +28,8 @@ def launch(
     rabbitmq_url = rabbitmq.launch(plan, rabbitmq_name, rabbitmq_image)
 
     launch_method = _get_launcher(plan, participant)
-    cl_node_name = _generate_name(participant, id)
-    el_node_name = el_launcher.generate_name(participant, id, is_validator=True)
+    cl_node_name = generate_name(participant, id)
+    el_node_name = el_launcher.generate_name(participant, id)
     el_rpc_url = "http://{}:{}".format(el_node_name, el_shared.RPC_PORT_NUMBER)
     service = launch_method(
         plan,
@@ -85,7 +85,8 @@ def _get_launcher(plan, participant):
     return LAUNCHERS.get(cl_type)
 
 
-def _generate_name(participant, id):
+def generate_name(participant, id):
     cl_type = participant.get("cl_type")
     el_type = participant.get("el_type")
-    return "l2-cl-{}-{}-{}-validator".format(id, cl_type, el_type)
+    suffix = participant.get("kind")
+    return "l2-cl-{}-{}-{}-{}".format(id, cl_type, el_type, suffix)

--- a/src/cl/launcher.star
+++ b/src/cl/launcher.star
@@ -23,7 +23,7 @@ def launch(
     node_ids,
     l1_rpc_url,
 ):
-    rabbitmq_name = rabbitmq.generate_name(id)
+    rabbitmq_name = "rabbitmq-l2-cl-{}-{}".format(id, participant.get("kind"))
     rabbitmq_image = participant.get("cl_db_image")
     rabbitmq_url = rabbitmq.launch(plan, rabbitmq_name, rabbitmq_image)
 

--- a/src/cl/rabbitmq.star
+++ b/src/cl/rabbitmq.star
@@ -24,7 +24,3 @@ def launch(plan, name, image):
         name,
         RABBITMQ_AMQP_PORT_NUMBER,
     )
-
-
-def generate_name(id):
-    return "rabbitmq-l2-cl-{}-validator".format(id)

--- a/src/el/bor/launcher.star
+++ b/src/el/bor/launcher.star
@@ -21,7 +21,6 @@ def launch(
     el_static_nodes,
     el_chain_id,
 ):
-    is_validator = participant.get("is_validator")
     bor_node_config_artifact = plan.render_templates(
         name="{}-node-config".format(el_node_name),
         config={
@@ -32,7 +31,7 @@ def launch(
                     "node_name": el_node_name,
                     "config_folder_path": BOR_CONFIG_FOLDER_PATH,
                     "data_folder_path": BOR_APP_DATA_FOLDER_PATH,
-                    "is_validator": is_validator,
+                    "kind": participant.get("kind"),
                     "address": el_account.eth_tendermint.address,
                     "cl_node_url": cl_node_url,
                     "log_level_to_int": log_level_to_int(

--- a/src/el/erigon/launcher.star
+++ b/src/el/erigon/launcher.star
@@ -22,7 +22,6 @@ def launch(
     el_static_nodes,
     el_chain_id,
 ):
-    is_validator = participant.get("is_validator")
     erigon_node_config_artifact = plan.render_templates(
         name="{}-node-config".format(el_node_name),
         config={
@@ -33,7 +32,7 @@ def launch(
                     "node_name": el_node_name,
                     "config_folder_path": ERIGON_CONFIG_FOLDER_PATH,
                     "data_folder_path": ERIGON_APP_DATA_FOLDER_PATH,
-                    "is_validator": is_validator,
+                    "kind": participant.get("kind"),
                     "address": el_account.eth_tendermint.address,
                     "cl_node_url": cl_node_url,
                     "log_level": participant.get("el_log_level"),

--- a/src/el/launcher.star
+++ b/src/el/launcher.star
@@ -16,14 +16,13 @@ def launch(
     plan,
     participant,
     id,
-    is_validator,
     el_genesis_artifact,
     cl_api_url,
     el_account,
     el_static_nodes,
     el_chain_id,
 ):
-    el_node_name = generate_name(participant, id, is_validator)
+    el_node_name = generate_name(participant, id)
 
     # Generate keystore, nodekey and password.
     el_credentials_artifact = _generate_credentials(
@@ -118,10 +117,10 @@ def _get_launcher(participant):
     return LAUNCHERS.get(el_type)
 
 
-def generate_name(participant, id, is_validator=False):
+def generate_name(participant, id):
     cl_type = participant.get("cl_type")
     el_type = participant.get("el_type")
-    suffix = "validator" if is_validator else "rpc"
+    suffix = participant.get("kind")
     return "l2-el-{}-{}-{}-{}".format(
         id,
         el_type,

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -42,7 +42,7 @@ def launch(
     all_participants = []
     first_cl_context = None
     for _, participant in enumerate(participants):
-        is_validator = participant.get("is_validator")
+        is_validator = participant_module.is_validator(participant)
         for _ in range(participant.get("count")):
             plan.print(
                 "Launching participant {} with config: {}".format(
@@ -84,7 +84,6 @@ def launch(
                 plan,
                 participant,
                 participant_index + 1,
-                is_validator,
                 el_genesis_artifact,
                 cl_api_url,
                 el_account,
@@ -95,11 +94,11 @@ def launch(
             # Add the node to the all_participants array.
             all_participants.append(
                 participant_module.new_participant(
+                    kind=participant.get("kind"),
                     cl_type=participant.get("cl_type"),
                     el_type=participant.get("el_type"),
                     cl_context=cl_context or first_cl_context,
                     el_context=el_context,
-                    is_validator=is_validator,
                 )
             )
 
@@ -157,7 +156,7 @@ def _prepare_network_data(participants):
             el_static_nodes.append(enode_url)
 
             # Generate validator configurations.
-            if participant.get("is_validator"):
+            if participant_module.is_validator(participant):
                 cl_node_name = _generate_cl_node_name(
                     participant, participant_index + 1
                 )
@@ -265,15 +264,8 @@ def _read_cl_persistent_peers(plan, cl_persistent_peers_artifact):
 
 
 def _generate_cl_node_name(participant, id):
-    return "l2-cl-{}-{}-{}-validator".format(
-        id, participant.get("cl_type"), participant.get("el_type")
-    )
+    return cl_launcher.generate_name(participant, id)
 
 
 def _generate_el_node_name(participant, id):
-    return "l2-el-{}-{}-{}-{}".format(
-        id,
-        participant.get("el_type"),
-        participant.get("cl_type"),
-        "validator" if participant.get("is_validator") else "rpc",
-    )
+    return el_launcher.generate_name(participant, id)

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -42,7 +42,7 @@ def launch(
     all_participants = []
     first_cl_context = None
     for _, participant in enumerate(participants):
-        is_validator = participant_module.is_validator(participant)
+        is_validator = participant.get("kind") == constants.PARTICIPANT_KIND.validator
         for _ in range(participant.get("count")):
             plan.print(
                 "Launching participant {} with config: {}".format(
@@ -156,7 +156,8 @@ def _prepare_network_data(participants):
             el_static_nodes.append(enode_url)
 
             # Generate validator configurations.
-            if participant_module.is_validator(participant):
+            is_validator = participant.get("kind") == constants.PARTICIPANT_KIND.validator
+            if is_validator:
                 cl_node_name = _generate_cl_node_name(
                     participant, participant_index + 1
                 )

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -142,25 +142,23 @@ def _prepare_network_data(participants):
     # Iterate through all participants in the network and generate necessary configurations.
     participant_index = 0
     validator_index = 0
-    for _, participant in enumerate(participants):
-        for _ in range(participant.get("count")):
-            el_node_name = _generate_el_node_name(participant, participant_index + 1)
+    for _, p in enumerate(participants):
+        for _ in range(p.get("count")):
+            el_node_name = _generate_el_node_name(p, participant_index + 1)
             account = prefunded_accounts.PREFUNDED_ACCOUNTS[participant_index]
 
             # Generate the EL enode url.
             enode_url = _generate_enode_url(
-                participant,
+                p,
                 account.eth_tendermint.public_key.removeprefix("0x"),
                 el_node_name,
             )
             el_static_nodes.append(enode_url)
 
             # Generate validator configurations.
-            is_validator = participant.get("kind") == constants.PARTICIPANT_KIND.validator
+            is_validator = p.get("kind") == constants.PARTICIPANT_KIND.validator
             if is_validator:
-                cl_node_name = _generate_cl_node_name(
-                    participant, participant_index + 1
-                )
+                cl_node_name = _generate_cl_node_name(p, participant_index + 1)
 
                 # Generate the CL validator config.
                 cl_validator_config = "{},{},{},{},{}:{}".format(

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -3,7 +3,6 @@ math = import_module("../math/math.star")
 PARTICIPANT_KIND = struct(
     validator="validator",
     rpc="rpc",
-    stateless="stateless",
 )
 
 EL_TYPE = struct(

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -1,5 +1,10 @@
 math = import_module("../math/math.star")
 
+PARTICIPANT_KIND = struct(
+    validator="validator",
+    rpc="rpc",
+    stateless="stateless",
+)
 
 EL_TYPE = struct(
     bor="bor",

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -41,6 +41,7 @@ DEFAULT_ETHEREUM_PACKAGE_ARGS = {
 }
 
 DEFAULT_POLYGON_POS_PARTICIPANT = {
+    "kind": constants.PARTICIPANT_KIND.validator,
     "el_type": constants.EL_TYPE.bor,
     "el_image": DEFAULT_EL_IMAGES[constants.EL_TYPE.bor],
     "el_log_level": constants.LOG_LEVEL.info,
@@ -48,7 +49,6 @@ DEFAULT_POLYGON_POS_PARTICIPANT = {
     "cl_image": DEFAULT_CL_IMAGES[constants.CL_TYPE.heimdall],
     "cl_log_level": constants.LOG_LEVEL.info,
     "cl_db_image": DEFAULT_CL_DB_IMAGE,
-    "is_validator": True,
     "count": 1,
 }
 
@@ -56,11 +56,13 @@ DEFAULT_POLYGON_POS_PACKAGE_ARGS = {
     "participants": [
         DEFAULT_POLYGON_POS_PARTICIPANT
         | {
+            "kind": constants.PARTICIPANT_KIND.validator,
             "count": 2,
         },
         DEFAULT_POLYGON_POS_PARTICIPANT
         | {
-            "is_validator": False,
+            "kind": constants.PARTICIPANT_KIND.rpc,
+            "count": 1,
         },
     ],
     "setup_images": {

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -5,6 +5,7 @@ prefunded_accounts_module = import_module("../prefunded_accounts/accounts.star")
 
 POLYGON_POS_PARAMS = {
     "participants": [
+        "kind",
         "el_type",
         "el_image",
         "el_log_level",
@@ -12,7 +13,6 @@ POLYGON_POS_PARAMS = {
         "cl_image",
         "cl_log_level",
         "cl_db_image",
-        "is_validator",
         "count",
     ],
     "setup_images": [
@@ -41,6 +41,12 @@ POLYGON_POS_PARAMS = {
         for field in dir(constants.ADDITIONAL_SERVICES)
     ],
 }
+
+VALID_PARTICIPANT_KINDS = [
+    constants.PARTICIPANT_KIND.validator,
+    constants.PARTICIPANT_KIND.rpc,
+    constants.PARTICIPANT_KIND.stateless,
+]
 
 VALID_CL_CLIENTS = [constants.CL_TYPE.heimdall, constants.CL_TYPE.heimdall_v2]
 VALID_EL_CLIENTS = [constants.EL_TYPE.bor, constants.EL_TYPE.erigon]
@@ -217,6 +223,7 @@ def _validate_participants_count(participants):
 
 
 def _validate_participant(p):
+    _validate_str(p, "kind", VALID_PARTICIPANT_KINDS)
     _validate_str(p, "cl_type", VALID_CL_CLIENTS)
     _validate_str(p, "el_type", VALID_EL_CLIENTS)
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -45,7 +45,6 @@ POLYGON_POS_PARAMS = {
 VALID_PARTICIPANT_KINDS = [
     constants.PARTICIPANT_KIND.validator,
     constants.PARTICIPANT_KIND.rpc,
-    constants.PARTICIPANT_KIND.stateless,
 ]
 
 VALID_CL_CLIENTS = [constants.CL_TYPE.heimdall, constants.CL_TYPE.heimdall_v2]

--- a/src/participant.star
+++ b/src/participant.star
@@ -1,14 +1,21 @@
+constants = import_module("./package_io/constants.star")
+
+
 def new_participant(
+    kind,
     el_type,
     cl_type,
     el_context,
     cl_context,
-    is_validator,
 ):
     return struct(
+        kind=kind,
         el_type=el_type,
         cl_type=cl_type,
         el_context=el_context,
         cl_context=cl_context,
-        is_validator=is_validator,
     )
+
+
+def is_validator(participant):
+    return participant.kind == constants.PARTICIPANT_KIND.validator

--- a/src/participant.star
+++ b/src/participant.star
@@ -15,7 +15,3 @@ def new_participant(
         el_context=el_context,
         cl_context=cl_context,
     )
-
-
-def is_validator(participant):
-    return participant.kind == constants.PARTICIPANT_KIND.validator

--- a/static_files/el/bor/config.toml
+++ b/static_files/el/bor/config.toml
@@ -22,9 +22,9 @@ syncmode = "full"
     password = "{{.config_folder_path}}/password.txt"
     unlock = ["{{.address}}"]
 
-{{if .is_validator}}
+{{if eq .kind "validator"}}
 [miner]
-    mine = {{.is_validator}}
+    mine = true
     gaslimit = 30000000
     gasprice = "25000000000"
     etherbase = "{{.address}}"

--- a/static_files/el/erigon/config.toml
+++ b/static_files/el/erigon/config.toml
@@ -21,8 +21,8 @@ staticpeers = "{{.static_nodes}}"
 "bor.waypoints" = false
 
 # [miner]
-{{if .is_validator}}
-mine = {{.is_validator}}
+{{if eq .kind "validator"}}
+mine = true
 "miner.gaslimit" = 30000000
 # "miner.gasprice" = "25000000000" # TODO: Make this flag available in erigon.
 "miner.etherbase" = "{{.address}}"


### PR DESCRIPTION
## Description

> **🚨 BREAKING CHANGE 🚨**

We'll soon need to support stateless nodes, and instead of adding complexity with a new `is_stateless` field - in addition to `is_validator`, this PR redefines how participant types are described. It introduces a new field, `kind`, to specify the role of a participant in the network:

- `validator`: Responsible for validating and proposing blocks.
- `rpc`: Provides RPC endpoints for interacting with the network (e.g., querying data, sending transactions).
- `stateless`: A lightweight participant that does not maintain state but serves other purposes (e.g., monitoring or relaying data) - not available yet!
