### PR TITLE
chore: bump to bor to `2.0.3`

### DIFF
--- a/.github/tests/nightly/all.yml
+++ b/.github/tests/nightly/all.yml
@@ -17,7 +17,7 @@ polygon_pos_package:
   participants:
     - kind: validator
       el_type: bor
-      el_image: 0xpolygon/bor:2.0.1
+      el_image: 0xpolygon/bor:2.0.3
       el_log_level: info
       cl_type: heimdall
       cl_image: 0xpolygon/heimdall:1.2.3

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ polygon_pos_package:
     - kind: validator
       cl_type: heimdall
       el_type: bor
-      el_image: 0xpolygon/bor:2.0.1
+      el_image: 0xpolygon/bor:2.0.3
       count: 2
     - kind: rpc
       cl_type: heimdall
@@ -193,7 +193,7 @@ polygon_pos_package:
     - kind: validator
       cl_type: heimdall
       el_type: bor
-      el_image: 0xpolygon/bor:2.0.0 # default: 0xpolygon/bor:2.0.1
+      el_image: 0xpolygon/bor:2.0.0 # default: 0xpolygon/bor:2.0.3
       count: 2
     - kind: rpc
       cl_type: heimdall
@@ -280,10 +280,10 @@ polygon_pos_package:
       # The docker image that should be used for the EL client.
       # Leave blank to use the default image for the client type.
       # Defaults by client:
-      # - bor: "0xpolygon/bor:2.0.1"
+      # - bor: "0xpolygon/bor:2.0.3"
       # - bor modified for heimdall-v2: "leovct/bor:1a6957c"
       # - erigon: "erigontech/erigon:main-767a6d6"
-      el_image: 0xpolygon/bor:2.0.1
+      el_image: 0xpolygon/bor:2.0.3
 
       # The log level string that this participant's EL client should log at.
       # Leave blank to use the default log level, info.

--- a/src/config/input_parser.star
+++ b/src/config/input_parser.star
@@ -7,7 +7,7 @@ DEFAULT_POS_EL_GENESIS_BUILDER_IMAGE = "leovct/pos-el-genesis-builder:96a19dd"
 DEFAULT_POS_VALIDATOR_CONFIG_GENERATOR_IMAGE = "leovct/pos-validator-config-generator:1.2.3-0.1.9"  # Based on 0xpolygon/heimdall:1.2.3 and 0xpolygon/heimdall-v2:0.1.9.
 
 DEFAULT_EL_IMAGES = {
-    constants.EL_TYPE.bor: "0xpolygon/bor:2.0.1",
+    constants.EL_TYPE.bor: "0xpolygon/bor:2.0.3",
     constants.EL_TYPE.bor_modified_for_heimdall_v2: "leovct/bor:d1371e4",  # There is no official image yet.
     constants.EL_TYPE.erigon: "erigontech/erigon:main-767a6d6",  # TODO: Use an official tag.
 }


### PR DESCRIPTION
- https://github.com/maticnetwork/bor/releases/tag/v2.0.3
- https://github.com/maticnetwork/bor/releases/tag/v2.0.2