### PR TITLE
docs: nit

### DIFF
--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -29,62 +29,44 @@ Do not combine an args file with on-the-fly arguments as Kurtosis cannot merge p
 
 Below are some sample configurations to help you get started. Feel free to copy and adapt these examples to fit your use case. You can find more examples in the `.github/configs/` directory.
 
-### Heimdall - Bor Devnet
+### Heimdall/Bor Devnet
 
-```yml title=".github/configs/heimdall-bor.yml"
-polygon_pos_package:
-  participants:
-    - kind: validator
-      cl_type: heimdall
-      el_type: bor
-      count: 4
-    - kind: rpc
-      cl_type: heimdall
-      el_type: bor
-      count: 2
+This configuration deploys 4 heimdall/bor validator nodes as well as 2 rpc nodes.
+
+To deploy this environment:
+
+```bash
+kurtosis run --enclave pos --args-file .github/configs/heimdall-bor.yml .
 ```
 
-### Heimdall - Erigon Devnet
+### Heimdall/Erigon Devnet
 
-```yml title=".github/configs/heimdall-erigon.yml"
-polygon_pos_package:
-  participants:
-    - kind: validator
-      cl_type: heimdall
-      el_type: erigon
-      count: 4
-    - kind: rpc
-      cl_type: heimdall
-      el_type: erigon
-      count: 2
+This configuration deploys 4 heimdall/erigon validator nodes as well as 2 rpc nodes.
 
-  network_params:
-    cl_environment: local
+To deploy this environment:
+
+```bash
+kurtosis run --enclave pos --args-file .github/configs/heimdall-erigon.yml .
 ```
 
-### Heimdall-v2 - Bor Devnet
+### Heimdall-v2/Bor Devnet
 
-```yml title=".github/configs/heimdall-v2-bor.yml"
-polygon_pos_package:
-  participants:
-    - kind: validator
-      cl_type: heimdall-v2
-      el_type: bor
-      count: 4
-    - kind: rpc
-      cl_type: heimdall-v2
-      el_type: bor
-      count: 2
+This configuration deploys 4 heimdall-v2/bor validator nodes as well as 2 rpc nodes.
+
+To deploy this environment:
+
+```bash
+kurtosis run --enclave pos --args-file .github/configs/heimdall-v2-bor.yml .
 ```
 
-### Default Devnet with Observability and Test Runner
+### Observability
 
-```yml title=".github/configs/additional-services.yml"
-polygon_pos_package:
-  additional_services:
-    - prometheus_grafana
-    - test_runner
+This configuration is ideal for development teams who need a complete testing environment with comprehensive monitoring. It deploys the default Heimdall/Bor setup enhanced with debugging and observability tools, making it perfect for development, testing, and troubleshooting.
 
+To deploy this environment:
+
+```bash
+kurtosis run --enclave pos --args-file .github/configs/additional-services.yml .
 ```
 
 Explore the [Configuration Schema](reference.md) for a detailed breakdown of all available options.

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -22,7 +22,7 @@ This guide will help you get started quickly. For more details, see the [full do
 Run Kurtosis linter:
 
 ```bash
-kurtosis lint .
+kurtosis lint --format .
 ```
 
 ### Testing
@@ -49,7 +49,7 @@ npm run build
 To preview docs locally:
 
 ```bash
-npm run start
+npm run serve
 ```
 
 Then visit http://localhost:3000.


### PR DESCRIPTION
- Replace YAML example configurations with `kurtosis run` command examples.
- Revise the lint and serve instructions in the contributing documentation.