### PR TITLE
feat: use erigon `v3.0.5`

### DIFF
--- a/src/config/input_parser.star
+++ b/src/config/input_parser.star
@@ -9,7 +9,7 @@ DEFAULT_POS_VALIDATOR_CONFIG_GENERATOR_IMAGE = "leovct/pos-validator-config-gene
 DEFAULT_EL_IMAGES = {
     constants.EL_TYPE.bor: "0xpolygon/bor:2.1.0",
     constants.EL_TYPE.bor_modified_for_heimdall_v2: "leovct/bor:84794ac",  # There is no official image yet.
-    constants.EL_TYPE.erigon: "erigontech/erigon:main-latest",  # TODO: Use an official tag.
+    constants.EL_TYPE.erigon: "erigontech/erigon:v3.0.5",  # TODO: Use an official tag.
 }
 
 DEFAULT_CL_IMAGES = {


### PR DESCRIPTION
We had been using `erigontech/erigon:main-latest` because the `main` branch included important changes that weren’t available in previous erigon releases. However, those changes have since been merged into the latest official releases.

Now, continuing to use the latest `main-latest` image is problematic — it includes recent heimdall-v2 updates that introduce breaking changes to the API, which are currently incompatible with our setup.