### PR TITLE
ci: fix `nightly`

### DIFF
--- a/.github/configs/nightly/cl-el-genesis/polygon-pos-with-cl-el-genesis.yml
+++ b/.github/configs/nightly/cl-el-genesis/polygon-pos-with-cl-el-genesis.yml
@@ -3,6 +3,6 @@ dev:
   l1_rpc_url: http://el-1-geth-lighthouse:8545
 
   should_deploy_matic_contracts: false
-  l2_cl_genesis_filepath: .github/configs/cl-el-genesis/l2-cl-genesis.json
-  l2_el_genesis_filepath: .github/configs/cl-el-genesis/l2-el-genesis.json
-  matic_contract_addresses_filepath: .github/configs/cl-el-genesis/matic-contract-addresses.json
+  l2_cl_genesis_filepath: .github/configs/nightly/cl-el-genesis/l2-cl-genesis.json
+  l2_el_genesis_filepath: .github/configs/nightly/cl-el-genesis/l2-el-genesis.json
+  matic_contract_addresses_filepath: .github/configs/nightly/cl-el-genesis/matic-contract-addresses.json

--- a/.github/workflows/kurtosis-deploy.yaml
+++ b/.github/workflows/kurtosis-deploy.yaml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-matrix
         run: |
-          file_paths=$(ls -R ./.github/configs/{*,*/*}.yml | grep -Ev "cl-el-genesis|external-l1|nightly")
+          file_paths=$(ls -R ./.github/configs/{*,*/*}.yml | grep -Ev "nightly")
           echo "file_paths=${file_paths}"
 
           matrix=$(echo "${file_paths}" | while read -r file_path; do

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-matrix
         run: |
-          file_paths=$(ls -R ./.github/configs/nightly/{*,*/*}.yml)
+          file_paths=$(ls -R ./.github/configs/nightly/{*,*/*}.yml | grep -Ev "cl-el-genesis|external-l1")
           echo "file_paths=${file_paths}"
 
           matrix=$(echo "${file_paths}" | while read -r file_path; do


### PR DESCRIPTION
#162 moved several jobs from the main deploy workflow to the nightly workflow but missed updating two key aspects:

1. The file artifact paths in the `run-with-cl-el-genesis` job were not updated to match the new directory structure, causing the job to fail.

2. The `list-ymls` job in the nightly workflow does not exclude the two custom environments, `cl-el-genesis` and `external-l1`. These environments require custom logic for deployment and should be triggered separately using their dedicated jobs.

For reference: https://github.com/0xPolygon/kurtosis-polygon-pos/actions/runs/15699413567/job/44230785654