### PR TITLE
chore: document stateless testing and add ci test

### DIFF
--- a/.github/workflows/kurtosis-deploy.yaml
+++ b/.github/workflows/kurtosis-deploy.yaml
@@ -139,7 +139,7 @@ jobs:
           bor_branch="stateless_sync"
           bor_commit_sha="5e4bde2" # 2025/06/24
           image_name="local/bor:${bor_commit_sha}"
-          git clone --branch "${bor_branch}" git@github.com:maticnetwork/bor.git
+          git clone --branch "${bor_branch}" https://github.com/maticnetwork/bor.git
           pushd bor
           git checkout "${bor_commit_sha}"
           docker build --tag "${image_name}" .
@@ -149,7 +149,7 @@ jobs:
           heimdall_v2_branch="stateless_sync"
           heimdall_v2_commit_sha="52224d7" # 2025/06/25
           image_name="local/heimdall-v2:${heimdall_v2_commit_sha}"
-          git clone --branch "${heimdall_v2_branch}" git@github.com:0xPolygon/heimdall-v2.git
+          git clone --branch "${heimdall_v2_branch}" https://github.com/0xPolygon/heimdall-v2.git
           pushd heimdall_v2
           git checkout "${heimdall_v2_commit_sha}"
           docker build --tag "${image_name}" .

--- a/.github/workflows/kurtosis-deploy.yaml
+++ b/.github/workflows/kurtosis-deploy.yaml
@@ -192,4 +192,4 @@ jobs:
         uses: ./.github/actions/kurtosis-post-run
         with:
           enclave_name: ${{ env.ENCLAVE_NAME }}
-          args_filename: ${{ matrix.file.name }}
+          args_filename: stateless

--- a/.github/workflows/kurtosis-deploy.yaml
+++ b/.github/workflows/kurtosis-deploy.yaml
@@ -150,7 +150,7 @@ jobs:
           heimdall_v2_commit_sha="52224d7" # 2025/06/25
           image_name="local/heimdall-v2:${heimdall_v2_commit_sha}"
           git clone --branch "${heimdall_v2_branch}" https://github.com/0xPolygon/heimdall-v2.git
-          pushd heimdall_v2
+          pushd heimdall-v2
           git checkout "${heimdall_v2_commit_sha}"
           docker build --tag "${image_name}" .
 

--- a/.github/workflows/kurtosis-deploy.yaml
+++ b/.github/workflows/kurtosis-deploy.yaml
@@ -128,6 +128,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Try to free up disk space (around 6 GB) before running the kurtosis job.
+      # This is needed because the job fails with "System.IO.IOException: No space left on device".
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # 2023/10/19
+        with:
+          tool-cache: true
+
       - name: Pre kurtosis run
         uses: ./.github/actions/kurtosis-pre-run
         with:

--- a/.github/workflows/kurtosis-deploy.yaml
+++ b/.github/workflows/kurtosis-deploy.yaml
@@ -121,3 +121,48 @@ jobs:
         with:
           enclave_name: ${{ env.ENCLAVE_NAME }}
           args_filename: ${{ matrix.file.name }}
+  
+  run-with-stateless:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pre kurtosis run
+        uses: ./.github/actions/kurtosis-pre-run
+        with:
+          docker_username: ${{ secrets.DOCKER_USERNAME }}
+          docker_token: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Kurtosis run
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=stateless.yml .
+
+      - name: Inspect enclave
+        run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
+
+      - name: Check if test runner is deployed
+        id: check-test-runner
+        run: |
+          # The test runner is deployed by default.
+          test_runner_deployed=true
+
+          # Verify if additional services are defined and ensure the test runner is deployed.
+          additional_services=$(yq '.polygon_pos_package.additional_services' stateless.yml)
+          if [[ "${additional_services}" != "null" ]]; then
+            is_test_runner_deployed=$(yq '.polygon_pos_package.additional_services | contains(["test_runner"])' stateless.yml)
+            if [[ "${is_test_runner_deployed}" != "true" ]]; then
+              test_runner_deployed=false
+            fi
+          fi
+          echo "test_runner_deployed=${test_runner_deployed}" >> $GITHUB_OUTPUT
+
+      - name: Test state syncs
+        if: steps.check-test-runner.outputs.test_runner_deployed == 'true'
+        run: kurtosis service exec ${{ env.ENCLAVE_NAME }} test-runner "bats --filter-tags pos,bridge,matic,pol --recursive tests/"
+
+      - name: Post kurtosis run
+        if: always()
+        uses: ./.github/actions/kurtosis-post-run
+        with:
+          enclave_name: ${{ env.ENCLAVE_NAME }}
+          args_filename: ${{ matrix.file.name }}

--- a/.github/workflows/kurtosis-deploy.yaml
+++ b/.github/workflows/kurtosis-deploy.yaml
@@ -134,6 +134,26 @@ jobs:
           docker_username: ${{ secrets.DOCKER_USERNAME }}
           docker_token: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Build local bor image
+        run: |
+          bor_branch="stateless_sync"
+          bor_commit_sha="5e4bde2" # 2025/06/24
+          image_name="local/bor:${bor_commit_sha}"
+          git clone --branch "${bor_branch}" git@github.com:maticnetwork/bor.git
+          pushd bor
+          git checkout "${bor_commit_sha}"
+          docker build --tag "${image_name}" .
+
+      - name: Build local heimdall-v2 image
+        run: |
+          heimdall_v2_branch="stateless_sync"
+          heimdall_v2_commit_sha="52224d7" # 2025/06/25
+          image_name="local/heimdall-v2:${heimdall_v2_commit_sha}"
+          git clone --branch "${heimdall_v2_branch}" git@github.com:0xPolygon/heimdall-v2.git
+          pushd heimdall_v2
+          git checkout "${heimdall_v2_commit_sha}"
+          docker build --tag "${image_name}" .
+
       - name: Kurtosis run
         run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=stateless.yml .
 

--- a/STATELESS.md
+++ b/STATELESS.md
@@ -1,0 +1,35 @@
+# Stateless Node Testing
+
+## 1. Build Local Docker Images
+
+### Bor
+
+```bash
+bor_branch="stateless_sync"
+bor_commit_sha="5e4bde2" # 2025/06/24
+image_name="local/bor:${bor_commit_sha}"
+git clone --branch "${bor_branch}" git@github.com:maticnetwork/bor.git
+pushd bor
+git checkout "${bor_commit_sha}"
+docker build --tag "${image_name}" .
+popd
+```
+
+### Heimdall v2
+
+```bash
+heimdall_v2_branch="stateless_sync"
+heimdall_v2_commit_sha="52224d7" # 2025/06/25
+image_name="local/heimdall-v2:${heimdall_v2_commit_sha}"
+git clone --branch "${heimdall_v2_branch}" git@github.com:0xPolygon/heimdall-v2.git
+pushd heimdall_v2
+git checkout "${heimdall_v2_commit_sha}"
+docker build --tag "${image_name}" .
+popd
+```
+
+## 2. Deploy a Devnet
+
+```bash
+kurtosis run --enclave pos --args-file stateless.yml .
+```

--- a/STATELESS.md
+++ b/STATELESS.md
@@ -1,6 +1,19 @@
 # Stateless Node Testing
 
+This guide provides instructions for setting up and testing stateless nodes in the Polygon PoS devnet environment. Stateless nodes are a new type of node that can synchronize and verify blockchain state without storing the entire blockchain history, significantly reducing storage requirements and improving sync times.
+
+## Overview
+
+Stateless nodes in Polygon PoS:
+
+- Synchronize state from other nodes without downloading the full blockchain history.
+- Verify state using cryptographic proofs (witness data).
+- Require significantly less storage compared to full nodes.
+- Support both Bor (execution layer) and Heimdall v2 (consensus layer).
+
 ## 1. Build Local Docker Images
+
+To test stateless functionality, you'll need to build Docker images from specific branches that include the stateless sync implementation. These branches contain the experimental code for witness generation and stateless synchronization.
 
 ### Bor
 
@@ -30,6 +43,16 @@ popd
 
 ## 2. Deploy a Devnet
 
+Launch the Polygon PoS devnet with stateless node support using the provided configuration:
+
 ```bash
 kurtosis run --enclave pos --args-file stateless.yml .
 ```
+
+This deployment creates a comprehensive test environment that includes:
+
+- **Two validator nodes**: Generate witness data while producing blocks.
+- **Witness-enabled RPC node**: Provides witness data to other nodes.
+- **Hybrid RPC node**: Both generates and consumes witness data for testing bidirectional functionality.
+- **Standard RPC node**: Operates in traditional full-sync mode for comparison.
+- **Stateless node**: Demonstrates pure stateless synchronization using only witness data.

--- a/STATELESS.md
+++ b/STATELESS.md
@@ -35,7 +35,7 @@ heimdall_v2_branch="stateless_sync"
 heimdall_v2_commit_sha="52224d7" # 2025/06/25
 image_name="local/heimdall-v2:${heimdall_v2_commit_sha}"
 git clone --branch "${heimdall_v2_branch}" git@github.com:0xPolygon/heimdall-v2.git
-pushd heimdall_v2
+pushd heimdall-v2
 git checkout "${heimdall_v2_commit_sha}"
 docker build --tag "${image_name}" .
 popd

--- a/src/additional_services/test_runner.star
+++ b/src/additional_services/test_runner.star
@@ -104,7 +104,7 @@ def launch(
                 "L2_ERC20_TOKEN_ADDRESS": l2_erc20_token_address,
                 "L2_ERC721_TOKEN_ADDRESS": l2_erc721_token_address,
                 # Bridge tests parameters.
-                "TIMEOUT_SECONDS": "360",
+                "TIMEOUT_SECONDS": "600",
             },
             entrypoint=["bash", "-c"],
             cmd=["sleep infinity"],

--- a/src/contracts/deployer.star
+++ b/src/contracts/deployer.star
@@ -106,7 +106,7 @@ def deploy_l2_contracts_and_synchronise_l1_state(
             ),
         ],
         run="bash /opt/data/deploy-l2-contracts.sh",
-        wait="5m",
+        wait="10m",
     )
     artifact_count = len(result.files_artifacts)
     if artifact_count != 1:

--- a/stateless.yml
+++ b/stateless.yml
@@ -1,41 +1,38 @@
-# bor:local => https://github.com/maticnetwork/bor/tree/stateless_sync
-# heimdall-v2:local => https://github.com/0xPolygon/heimdall-v2/tree/stateless_sync
-
 polygon_pos_package:
   participants:
     # validator nodes
     - kind: validator
       cl_type: heimdall-v2
-      cl_image: heimdall-v2:local
+      cl_image: local/heimdall-v2:52224d7
       el_type: bor
-      el_image: bor:local
+      el_image: local/bor:5e4bde2
       count: 2
       el_produce_witness: true
 
     # rpc nodes
     - kind: rpc
       cl_type: heimdall-v2
-      cl_image: heimdall-v2:local
+      cl_image: local/heimdall-v2:52224d7
       el_type: bor
-      el_image: bor:local
+      el_image: local/bor:5e4bde2
       el_produce_witness: true
       el_sync_with_witness: false
       count: 2
 
     - kind: rpc
       cl_type: heimdall-v2
-      cl_image: heimdall-v2:local
+      cl_image: local/heimdall-v2:52224d7
       el_type: bor
-      el_image: bor:local
+      el_image: local/bor:5e4bde2
       el_produce_witness: true
       el_sync_with_witness: true
       count: 1
 
     - kind: rpc
       cl_type: heimdall-v2
-      cl_image: heimdall-v2:local
+      cl_image: local/heimdall-v2:52224d7
       el_type: bor
-      el_image: bor:local
+      el_image: local/bor:5e4bde2
       el_produce_witness: false
       el_sync_with_witness: false
       count: 1
@@ -43,9 +40,9 @@ polygon_pos_package:
     # stateless nodes
     - kind: stateless
       cl_type: heimdall-v2
-      cl_image: heimdall-v2:local
+      cl_image: local/heimdall-v2:52224d7
       el_type: bor
-      el_image: bor:local
+      el_image: local/bor:5e4bde2
       count: 1
 
   additional_services:

--- a/stateless.yml
+++ b/stateless.yml
@@ -47,3 +47,4 @@ polygon_pos_package:
 
   additional_services:
     - prometheus_grafana
+    - test_runner


### PR DESCRIPTION
- Add documentation for stateless node setup.
- Add CI workflow to test stateless devnet - it builds bor and heimdall-v2 local images on the fly.
- Increase the time taken to deploy L2 because it takes longer than the usual deployment.