### PR TITLE
chore: increase node startup timeout

### DIFF
--- a/src/cl/launcher.star
+++ b/src/cl/launcher.star
@@ -63,7 +63,9 @@ def wait_for_node_startup(plan, service_name):
         },
     )
     plan.wait(
-        description="Wait for '{}' to start up - it can take up to 1 minute".format(service_name),
+        description="Wait for '{}' to start up - it can take up to 1 minute".format(
+            service_name
+        ),
         service_name=service_name,
         recipe=recipe,
         field="extract.id",

--- a/src/cl/launcher.star
+++ b/src/cl/launcher.star
@@ -63,14 +63,14 @@ def wait_for_node_startup(plan, service_name):
         },
     )
     plan.wait(
-        description="Wait for '{}' to start up".format(service_name),
+        description="Wait for '{}' to start up - it can take up to 1 minute".format(service_name),
         service_name=service_name,
         recipe=recipe,
         field="extract.id",
         assertion="!=",
         target_value="",
         interval="1s",
-        timeout="10s",
+        timeout="1m",
     )
 
 

--- a/src/el/launcher.star
+++ b/src/el/launcher.star
@@ -95,7 +95,9 @@ def wait_for_node_startup(plan, service_name):
         },
     )
     plan.wait(
-        description="Wait for '{}' to start up - it can take up to 1 minute".format(service_name),
+        description="Wait for '{}' to start up - it can take up to 1 minute".format(
+            service_name
+        ),
         service_name=service_name,
         recipe=recipe,
         field="extract.enode",

--- a/src/el/launcher.star
+++ b/src/el/launcher.star
@@ -95,14 +95,14 @@ def wait_for_node_startup(plan, service_name):
         },
     )
     plan.wait(
-        description="Wait for '{}' to start up".format(service_name),
+        description="Wait for '{}' to start up - it can take up to 1 minute".format(service_name),
         service_name=service_name,
         recipe=recipe,
         field="extract.enode",
         assertion="!=",
         target_value="",
         interval="1s",
-        timeout="10s",
+        timeout="1m",
     )
 
 


### PR DESCRIPTION
The nightly deployment job for bor/heimdall-v2 devnets has been experiencing frequent failures due to nodes not starting within the current 10-second timeout window. For reference: https://github.com/0xPolygon/kurtosis-polygon-pos/actions/runs/16108840824/job/45448868090

This change increases the node startup timeout to 60 seconds to accommodate slower initialisation times and improve deployment reliability.

Nightly run with increased timeout: https://github.com/leovct/kurtosis-polygon-pos/actions/runs/16111726157