### PR TITLE
chore: bump bor to `2.2.8` and erigon to `3.0.14`

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -70,7 +70,7 @@ Default: two validators and one rpc.
 | cl_db_image   | string | rabbitmq:4.1.2       | Image for the CL database.                                                                  |
 | cl_log_level  | string | info                 | Log level for the CL client.                                                                |
 | el_type       | string | bor                  | Execution Layer (EL) client type.                                                           |
-| el_image      | string | 0xpolygon/bor:2.2.5  | Image for the EL client.                                                                    |
+| el_image      | string | 0xpolygon/bor:2.2.8  | Image for the EL client.                                                                    |
 | el_log_level  | string | info                 | Log level for the EL client.                                                                |
 | count         | int    | 1                    | Number of nodes to spin up for this participant.                                            |
 

--- a/src/config/input_parser.star
+++ b/src/config/input_parser.star
@@ -7,7 +7,7 @@ DEFAULT_POS_EL_GENESIS_BUILDER_IMAGE = "leovct/pos-el-genesis-builder:96a19dd"
 DEFAULT_POS_VALIDATOR_CONFIG_GENERATOR_IMAGE = "leovct/pos-validator-config-generator:1.6.0-0.2.7"  # Based on 0xpolygon/heimdall:1.6.0 and 0xpolygon/heimdall-v2:0.2.7.
 
 DEFAULT_EL_IMAGES = {
-    constants.EL_TYPE.bor: "0xpolygon/bor:2.2.5",
+    constants.EL_TYPE.bor: "0xpolygon/bor:2.2.8",
     constants.EL_TYPE.bor_modified_for_heimdall_v2: "leovct/bor:581a230ed-fix",  # There is no official image yet.
     constants.EL_TYPE.erigon: "erigontech/erigon:v3.0.14",
 }

--- a/src/config/input_parser.star
+++ b/src/config/input_parser.star
@@ -9,7 +9,7 @@ DEFAULT_POS_VALIDATOR_CONFIG_GENERATOR_IMAGE = "leovct/pos-validator-config-gene
 DEFAULT_EL_IMAGES = {
     constants.EL_TYPE.bor: "0xpolygon/bor:2.2.5",
     constants.EL_TYPE.bor_modified_for_heimdall_v2: "leovct/bor:581a230ed-fix",  # There is no official image yet.
-    constants.EL_TYPE.erigon: "erigontech/erigon:v3.0.13",
+    constants.EL_TYPE.erigon: "erigontech/erigon:v3.0.14",
 }
 
 DEFAULT_CL_IMAGES = {

--- a/src/config/input_parser.star
+++ b/src/config/input_parser.star
@@ -9,7 +9,7 @@ DEFAULT_POS_VALIDATOR_CONFIG_GENERATOR_IMAGE = "leovct/pos-validator-config-gene
 DEFAULT_EL_IMAGES = {
     constants.EL_TYPE.bor: "0xpolygon/bor:2.2.5",
     constants.EL_TYPE.bor_modified_for_heimdall_v2: "leovct/bor:581a230ed-fix",  # There is no official image yet.
-    constants.EL_TYPE.erigon: "erigontech/erigon:v3.0.12",
+    constants.EL_TYPE.erigon: "erigontech/erigon:v3.0.13",
 }
 
 DEFAULT_CL_IMAGES = {


### PR DESCRIPTION
- Bump erigon to [3.0.14](https://github.com/erigontech/erigon/releases/tag/v3.0.14)
- Bump bor to [2.2.8](https://github.com/maticnetwork/bor/releases/tag/v2.2.8)