### PR TITLE
chore: bump bor to `2.2.9`

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -70,7 +70,7 @@ Default: two validators and one rpc.
 | cl_db_image   | string | rabbitmq:4.1.2       | Image for the CL database.                                                                  |
 | cl_log_level  | string | info                 | Log level for the CL client.                                                                |
 | el_type       | string | bor                  | Execution Layer (EL) client type.                                                           |
-| el_image      | string | 0xpolygon/bor:2.2.8  | Image for the EL client.                                                                    |
+| el_image      | string | 0xpolygon/bor:2.2.9  | Image for the EL client.                                                                    |
 | el_log_level  | string | info                 | Log level for the EL client.                                                                |
 | count         | int    | 1                    | Number of nodes to spin up for this participant.                                            |
 

--- a/src/config/input_parser.star
+++ b/src/config/input_parser.star
@@ -7,7 +7,7 @@ DEFAULT_POS_EL_GENESIS_BUILDER_IMAGE = "leovct/pos-el-genesis-builder:96a19dd"
 DEFAULT_POS_VALIDATOR_CONFIG_GENERATOR_IMAGE = "leovct/pos-validator-config-generator:1.6.0-0.2.10"  # Based on 0xpolygon/heimdall:1.6.0 and 0xpolygon/heimdall-v2:0.2.10.
 
 DEFAULT_EL_IMAGES = {
-    constants.EL_TYPE.bor: "0xpolygon/bor:2.2.8",
+    constants.EL_TYPE.bor: "0xpolygon/bor:2.2.9",
     constants.EL_TYPE.erigon: "erigontech/erigon:v3.0.14",
 }
 


### PR DESCRIPTION
https://github.com/maticnetwork/bor/releases/tag/v2.2.9